### PR TITLE
chore(release): v0.2.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5de77091d3813e07cb63341abfb848d745883d30",
+  "baseline-sha": "975f1e49428a3026b53382efcf02ef65996b4d47",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.1.0",
-      "tag": "v0.1.0"
+      "version": "0.2.0",
+      "tag": "v0.2.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.2.0",
+      "tag": "badness-code-v0.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.1.0",
-      "tag": "v0.1.0"
+      "version": "0.2.0",
+      "tag": "v0.2.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.2.0",
+      "tag": "badness-code-v0.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.0](https://github.com/jolars/badness/compare/v0.1.0...v0.2.0) (2026-06-12)
+
+### Features
+- add vscode and open vsx extensions ([`975f1e4`](https://github.com/jolars/badness/commit/975f1e49428a3026b53382efcf02ef65996b4d47))
+- **npm:** package for npm ([`b3a576f`](https://github.com/jolars/badness/commit/b3a576fa970d2d07de9521a7a3c5f16c13c535d6))
+
 ## [0.1.0](https://github.com/jolars/badness/compare/v0.0.1...v0.1.0) (2026-06-12)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "annotate-snippets",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 readme = "README.md"
 description = "An LSP, formatter, and linter for LaTeX"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/badness/compare/badness-code-v0.1.0...badness-code-v0.2.0) (2026-06-12)
+
+### Features
+- add vscode and open vsx extensions ([`975f1e4`](https://github.com/jolars/badness/commit/975f1e49428a3026b53382efcf02ef65996b4d47))
+
+### Dependencies
+- updated badness to v0.2.0

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An LSP, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.1.0",
-    "@badness/linux-arm64-gnu": "0.1.0",
-    "@badness/linux-x64-musl": "0.1.0",
-    "@badness/linux-arm64-musl": "0.1.0",
-    "@badness/darwin-x64": "0.1.0",
-    "@badness/darwin-arm64": "0.1.0",
-    "@badness/win32-x64": "0.1.0",
-    "@badness/win32-arm64": "0.1.0"
+    "@badness/linux-x64-gnu": "0.2.0",
+    "@badness/linux-arm64-gnu": "0.2.0",
+    "@badness/linux-x64-musl": "0.2.0",
+    "@badness/linux-arm64-musl": "0.2.0",
+    "@badness/darwin-x64": "0.2.0",
+    "@badness/darwin-arm64": "0.2.0",
+    "@badness/win32-x64": "0.2.0",
+    "@badness/win32-arm64": "0.2.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.2.0](https://github.com/jolars/badness/compare/v0.1.0...v0.2.0) (2026-06-12)

### Features
- add vscode and open vsx extensions ([`975f1e4`](https://github.com/jolars/badness/commit/975f1e49428a3026b53382efcf02ef65996b4d47))
- **npm:** package for npm ([`b3a576f`](https://github.com/jolars/badness/commit/b3a576fa970d2d07de9521a7a3c5f16c13c535d6))

## [editors/code: 0.2.0](https://github.com/jolars/badness/compare/badness-code-v0.1.0...badness-code-v0.2.0) (2026-06-12)

### Features
- add vscode and open vsx extensions ([`975f1e4`](https://github.com/jolars/badness/commit/975f1e49428a3026b53382efcf02ef65996b4d47))

### Dependencies
- updated badness to v0.2.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).