### PR TITLE
chore(release): v0.4.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "193a85f2a201d73cd874665434ac6bc40c7038e5",
+  "baseline-sha": "c7c77a7aa96123c51fafb0fe0bf6e3e9e1a07aef",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.3.0",
-      "tag": "v0.3.0"
+      "version": "0.4.0",
+      "tag": "v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.3.0",
-      "tag": "badness-code-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-code-v0.4.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.3.0",
-      "tag": "v0.3.0"
+      "version": "0.4.0",
+      "tag": "v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.3.0",
-      "tag": "badness-code-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-code-v0.4.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/badness/compare/v0.3.0...v0.4.0) (2026-06-23)
+
+### Features
+- **semantic:** mark the cross-reference family inline ([`c7c77a7`](https://github.com/jolars/badness/commit/c7c77a7aa96123c51fafb0fe0bf6e3e9e1a07aef))
+- **semantic:** ingest CWL corpus as a bulk signature tier ([`4740bf5`](https://github.com/jolars/badness/commit/4740bf50d00fea3bdb5cd90e6c9de2924da051ec))
+- **lint:** don't withold lints that disturbs alignment ([`8ea1efc`](https://github.com/jolars/badness/commit/8ea1efccecda47fd2dc70324e5104356ca047505))
+- **bib:** diagnose missing field separator; fix value trivia attachment ([`e14751c`](https://github.com/jolars/badness/commit/e14751cfc096dd264eb29848511be21c4d13738d))
+- **bib:** autofix duplicate-field when values are identical ([`c34bd78`](https://github.com/jolars/badness/commit/c34bd780d2d19486ea3d99be61c9d409125148ce))
+- **bib:** duplicate-field lint rule ([`f2f6d60`](https://github.com/jolars/badness/commit/f2f6d60763077e165d292d416dd4171fbe60bad0))
+- **lsp:** rename labels and citation keys (textDocument/rename + prepareRename) ([`7b1d01b`](https://github.com/jolars/badness/commit/7b1d01b68e4c900a17402998919147594f0b235d))
+- **config:** badness.toml configuration (CLI) ([`8c68ca2`](https://github.com/jolars/badness/commit/8c68ca2fa47f3907bc98d8415c1246ac7a4755b7))
+- **project:** package load graph + package signatures into scope ([`f8e6bc7`](https://github.com/jolars/badness/commit/f8e6bc7f661c26be6fad15821bda09ce85168a43))
+- **semantic:** doc/ltxdoc prose↔code association query ([`a52f17c`](https://github.com/jolars/badness/commit/a52f17c5f4e22ea984ee92cd9cff9e8fc61ded4b))
+- **file-kind:** .ins installation-script support (plain code, Preserve) ([`85c9c7a`](https://github.com/jolars/badness/commit/85c9c7a73f7d208e1e1df909647229f04f5ec115))
+- **formatter:** .dtx two-layer formatting (foundation, Preserve) ([`6c7861f`](https://github.com/jolars/badness/commit/6c7861f1670f8222d36c87f645766c9ba3ef4a5b))
+- **semantic:** doc/ltxdoc signatures + DOC_COMMENT node (M3) ([`95ec2a2`](https://github.com/jolars/badness/commit/95ec2a24bbb88d28fc4394abc0137182b7780f5b))
+- **parser:** lex expl3 syntax mode (_/: as letters) ([`c98e2e8`](https://github.com/jolars/badness/commit/c98e2e84ad78cc3413db1ba0b0eb8bf13be53d86))
+- **parser:** lex .dtx docstrip guards as GUARD tokens (M2) ([`b09c507`](https://github.com/jolars/badness/commit/b09c507c3e3901f52e2d12c0c3c87976b0712c99))
+- **parser:** parse .dtx docstrip surface syntax (M0+M1) ([`8e54604`](https://github.com/jolars/badness/commit/8e54604fbd80fcfd0e585d927e54f1096a086e36))
+- **lsp:** add textDocument/foldingRange ([`f0ea513`](https://github.com/jolars/badness/commit/f0ea51356645dce2076ea23c55386e34e9979bac))
+
+### Bug Fixes
+- **cli:** fix file-detection in cli linter ([`7821b6a`](https://github.com/jolars/badness/commit/7821b6ae35cca242933d862b59206b5443261c8b))
+
 ## [0.3.0](https://github.com/jolars/badness/compare/v0.2.0...v0.3.0) (2026-06-21)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 readme = "README.md"
 description = "An LSP, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/badness/compare/badness-code-v0.3.0...badness-code-v0.4.0) (2026-06-23)
+
+### Dependencies
+- updated badness to v0.4.0
+
 ## [0.3.0](https://github.com/jolars/badness/compare/badness-code-v0.2.0...badness-code-v0.3.0) (2026-06-21)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An LSP, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.3.0",
-    "@badness/linux-arm64-gnu": "0.3.0",
-    "@badness/linux-x64-musl": "0.3.0",
-    "@badness/linux-arm64-musl": "0.3.0",
-    "@badness/darwin-x64": "0.3.0",
-    "@badness/darwin-arm64": "0.3.0",
-    "@badness/win32-x64": "0.3.0",
-    "@badness/win32-arm64": "0.3.0"
+    "@badness/linux-x64-gnu": "0.4.0",
+    "@badness/linux-arm64-gnu": "0.4.0",
+    "@badness/linux-x64-musl": "0.4.0",
+    "@badness/linux-arm64-musl": "0.4.0",
+    "@badness/darwin-x64": "0.4.0",
+    "@badness/darwin-arm64": "0.4.0",
+    "@badness/win32-x64": "0.4.0",
+    "@badness/win32-arm64": "0.4.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.4.0](https://github.com/jolars/badness/compare/v0.3.0...v0.4.0) (2026-06-23)

### Features
- **semantic:** mark the cross-reference family inline ([`c7c77a7`](https://github.com/jolars/badness/commit/c7c77a7aa96123c51fafb0fe0bf6e3e9e1a07aef))
- **semantic:** ingest CWL corpus as a bulk signature tier ([`4740bf5`](https://github.com/jolars/badness/commit/4740bf50d00fea3bdb5cd90e6c9de2924da051ec))
- **lint:** don't withold lints that disturbs alignment ([`8ea1efc`](https://github.com/jolars/badness/commit/8ea1efccecda47fd2dc70324e5104356ca047505))
- **bib:** diagnose missing field separator; fix value trivia attachment ([`e14751c`](https://github.com/jolars/badness/commit/e14751cfc096dd264eb29848511be21c4d13738d))
- **bib:** autofix duplicate-field when values are identical ([`c34bd78`](https://github.com/jolars/badness/commit/c34bd780d2d19486ea3d99be61c9d409125148ce))
- **bib:** duplicate-field lint rule ([`f2f6d60`](https://github.com/jolars/badness/commit/f2f6d60763077e165d292d416dd4171fbe60bad0))
- **lsp:** rename labels and citation keys (textDocument/rename + prepareRename) ([`7b1d01b`](https://github.com/jolars/badness/commit/7b1d01b68e4c900a17402998919147594f0b235d))
- **config:** badness.toml configuration (CLI) ([`8c68ca2`](https://github.com/jolars/badness/commit/8c68ca2fa47f3907bc98d8415c1246ac7a4755b7))
- **project:** package load graph + package signatures into scope ([`f8e6bc7`](https://github.com/jolars/badness/commit/f8e6bc7f661c26be6fad15821bda09ce85168a43))
- **semantic:** doc/ltxdoc prose↔code association query ([`a52f17c`](https://github.com/jolars/badness/commit/a52f17c5f4e22ea984ee92cd9cff9e8fc61ded4b))
- **file-kind:** .ins installation-script support (plain code, Preserve) ([`85c9c7a`](https://github.com/jolars/badness/commit/85c9c7a73f7d208e1e1df909647229f04f5ec115))
- **formatter:** .dtx two-layer formatting (foundation, Preserve) ([`6c7861f`](https://github.com/jolars/badness/commit/6c7861f1670f8222d36c87f645766c9ba3ef4a5b))
- **semantic:** doc/ltxdoc signatures + DOC_COMMENT node (M3) ([`95ec2a2`](https://github.com/jolars/badness/commit/95ec2a24bbb88d28fc4394abc0137182b7780f5b))
- **parser:** lex expl3 syntax mode (_/: as letters) ([`c98e2e8`](https://github.com/jolars/badness/commit/c98e2e84ad78cc3413db1ba0b0eb8bf13be53d86))
- **parser:** lex .dtx docstrip guards as GUARD tokens (M2) ([`b09c507`](https://github.com/jolars/badness/commit/b09c507c3e3901f52e2d12c0c3c87976b0712c99))
- **parser:** parse .dtx docstrip surface syntax (M0+M1) ([`8e54604`](https://github.com/jolars/badness/commit/8e54604fbd80fcfd0e585d927e54f1096a086e36))
- **lsp:** add textDocument/foldingRange ([`f0ea513`](https://github.com/jolars/badness/commit/f0ea51356645dce2076ea23c55386e34e9979bac))

### Bug Fixes
- **cli:** fix file-detection in cli linter ([`7821b6a`](https://github.com/jolars/badness/commit/7821b6ae35cca242933d862b59206b5443261c8b))

## [editors/code: 0.4.0](https://github.com/jolars/badness/compare/badness-code-v0.3.0...badness-code-v0.4.0) (2026-06-23)

### Dependencies
- updated badness to v0.4.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).