### PR TITLE
chore(release): v0.5.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "c7c77a7aa96123c51fafb0fe0bf6e3e9e1a07aef",
+  "baseline-sha": "5ad2827e9ecd7046bd9465ee965fb5666d1ffe28",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.4.0",
-      "tag": "v0.4.0"
+      "version": "0.5.0",
+      "tag": "v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.4.0",
-      "tag": "badness-code-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-code-v0.5.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.4.0",
-      "tag": "v0.4.0"
+      "version": "0.5.0",
+      "tag": "v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.4.0",
-      "tag": "badness-code-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-code-v0.5.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/badness/compare/v0.4.0...v0.5.0) (2026-07-01)
+
+### Features
+- **lsp:** add range formatting support ([`5ad2827`](https://github.com/jolars/badness/commit/5ad2827e9ecd7046bd9465ee965fb5666d1ffe28))
+- **lsp:** add workspace symbols support ([`eb8a111`](https://github.com/jolars/badness/commit/eb8a111c18d346f73e34dcec39201ad28bf51da4))
+- **formatter:** format expl3 code (catcode 9/10 model) ([`ac4ff31`](https://github.com/jolars/badness/commit/ac4ff313fdad326bd0bf854b1f268c4d7d4b580a))
+- **lsp:** watch on-disk tex/bib/config and reanalyze ([`b551c01`](https://github.com/jolars/badness/commit/b551c0123d8a0cc174cbb8f3612c04ef883af371))
+- **dtx:** reflow documentation prose under reflow ([`be57646`](https://github.com/jolars/badness/commit/be576463c1bb4c32972dc47fc306065c43a991c1))
+- **lsp:** outline entries for dtx documented macros ([`cba0b01`](https://github.com/jolars/badness/commit/cba0b01003f5056ccfca0f2c5e9297bd3247969c))
+- **lsp:** add `textDocument/documentHighlight` ([`404069b`](https://github.com/jolars/badness/commit/404069b84ad75450f500378c842efe38fa7e3ba3))
+- **bench:** add formatter speed bench vs tex-fmt & latexindent ([`82ddeb5`](https://github.com/jolars/badness/commit/82ddeb54ff218882ad3e1a1fd6228af1cd3a8081))
+- **format:** reflow brace-group bodies as statements ([`bb976e0`](https://github.com/jolars/badness/commit/bb976e09cd701e315767cdcbd0b0bae6b536c1bc))
+- **lsp:** discover and apply badness.toml per document ([`e56a8af`](https://github.com/jolars/badness/commit/e56a8afc7621cd8e37df5848ab1a382739991e3e))
+- **lint:** add missing-nonbreaking-space (tie before cite/ref) ([`4d75da4`](https://github.com/jolars/badness/commit/4d75da4b9459361569f6d2407e5bdb675163c4ea))
+- **lsp:** surface linter autofixes as code actions ([`13c727e`](https://github.com/jolars/badness/commit/13c727e339d5e4c1f8e848caaf307b1fe9c9eb27))
+- **lsp:** resolve completion items with signature and citation detail ([`f9892e6`](https://github.com/jolars/badness/commit/f9892e62fb6ca1c804bc6f2912ea581a37d6b0bc))
+- **lsp:** add hover for commands, environments and citations ([`3c6047c`](https://github.com/jolars/badness/commit/3c6047cdae637bd18fb6216a8c1f52ec06460157))
+- **lsp:** add pull diagnostics ([`a73fd7b`](https://github.com/jolars/badness/commit/a73fd7b8f677b8fdca27be2d68bc3701beaaffc1))
+
+### Bug Fixes
+- **lsp:** honor excludes for siblings ([`7a50529`](https://github.com/jolars/badness/commit/7a5052953c3ef58174fa0f7f55f640a216c23428))
+
+### Performance Improvements
+- **signature:** bake CWL tier into a build-time phf map ([`a920d4a`](https://github.com/jolars/badness/commit/a920d4a803dcd89ab97e7dd7945148c95958de2c))
+
 ## [0.4.0](https://github.com/jolars/badness/compare/v0.3.0...v0.4.0) (2026-06-23)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -154,12 +154,12 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "97bf4965940c2382204c0ded6dd3dd48c0c4e872f1e76fb1bf94f45991a2cb6a"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "doc-utils"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/badness/compare/badness-code-v0.4.0...badness-code-v0.5.0) (2026-07-01)
+
+### Dependencies
+- updated badness to v0.5.0
+
 ## [0.4.0](https://github.com/jolars/badness/compare/badness-code-v0.3.0...badness-code-v0.4.0) (2026-06-23)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.4.0",
-    "@badness/linux-arm64-gnu": "0.4.0",
-    "@badness/linux-x64-musl": "0.4.0",
-    "@badness/linux-arm64-musl": "0.4.0",
-    "@badness/darwin-x64": "0.4.0",
-    "@badness/darwin-arm64": "0.4.0",
-    "@badness/win32-x64": "0.4.0",
-    "@badness/win32-arm64": "0.4.0"
+    "@badness/linux-x64-gnu": "0.5.0",
+    "@badness/linux-arm64-gnu": "0.5.0",
+    "@badness/linux-x64-musl": "0.5.0",
+    "@badness/linux-arm64-musl": "0.5.0",
+    "@badness/darwin-x64": "0.5.0",
+    "@badness/darwin-arm64": "0.5.0",
+    "@badness/win32-x64": "0.5.0",
+    "@badness/win32-arm64": "0.5.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.5.0](https://github.com/jolars/badness/compare/v0.4.0...v0.5.0) (2026-07-01)

### Features
- **lsp:** add range formatting support ([`5ad2827`](https://github.com/jolars/badness/commit/5ad2827e9ecd7046bd9465ee965fb5666d1ffe28))
- **lsp:** add workspace symbols support ([`eb8a111`](https://github.com/jolars/badness/commit/eb8a111c18d346f73e34dcec39201ad28bf51da4))
- **formatter:** format expl3 code (catcode 9/10 model) ([`ac4ff31`](https://github.com/jolars/badness/commit/ac4ff313fdad326bd0bf854b1f268c4d7d4b580a))
- **lsp:** watch on-disk tex/bib/config and reanalyze ([`b551c01`](https://github.com/jolars/badness/commit/b551c0123d8a0cc174cbb8f3612c04ef883af371))
- **dtx:** reflow documentation prose under reflow ([`be57646`](https://github.com/jolars/badness/commit/be576463c1bb4c32972dc47fc306065c43a991c1))
- **lsp:** outline entries for dtx documented macros ([`cba0b01`](https://github.com/jolars/badness/commit/cba0b01003f5056ccfca0f2c5e9297bd3247969c))
- **lsp:** add `textDocument/documentHighlight` ([`404069b`](https://github.com/jolars/badness/commit/404069b84ad75450f500378c842efe38fa7e3ba3))
- **bench:** add formatter speed bench vs tex-fmt & latexindent ([`82ddeb5`](https://github.com/jolars/badness/commit/82ddeb54ff218882ad3e1a1fd6228af1cd3a8081))
- **format:** reflow brace-group bodies as statements ([`bb976e0`](https://github.com/jolars/badness/commit/bb976e09cd701e315767cdcbd0b0bae6b536c1bc))
- **lsp:** discover and apply badness.toml per document ([`e56a8af`](https://github.com/jolars/badness/commit/e56a8afc7621cd8e37df5848ab1a382739991e3e))
- **lint:** add missing-nonbreaking-space (tie before cite/ref) ([`4d75da4`](https://github.com/jolars/badness/commit/4d75da4b9459361569f6d2407e5bdb675163c4ea))
- **lsp:** surface linter autofixes as code actions ([`13c727e`](https://github.com/jolars/badness/commit/13c727e339d5e4c1f8e848caaf307b1fe9c9eb27))
- **lsp:** resolve completion items with signature and citation detail ([`f9892e6`](https://github.com/jolars/badness/commit/f9892e62fb6ca1c804bc6f2912ea581a37d6b0bc))
- **lsp:** add hover for commands, environments and citations ([`3c6047c`](https://github.com/jolars/badness/commit/3c6047cdae637bd18fb6216a8c1f52ec06460157))
- **lsp:** add pull diagnostics ([`a73fd7b`](https://github.com/jolars/badness/commit/a73fd7b8f677b8fdca27be2d68bc3701beaaffc1))

### Bug Fixes
- **lsp:** honor excludes for siblings ([`7a50529`](https://github.com/jolars/badness/commit/7a5052953c3ef58174fa0f7f55f640a216c23428))

### Performance Improvements
- **signature:** bake CWL tier into a build-time phf map ([`a920d4a`](https://github.com/jolars/badness/commit/a920d4a803dcd89ab97e7dd7945148c95958de2c))

## [editors/code: 0.5.0](https://github.com/jolars/badness/compare/badness-code-v0.4.0...badness-code-v0.5.0) (2026-07-01)

### Dependencies
- updated badness to v0.5.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).