### PR TITLE
chore(release): v0.6.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5ad2827e9ecd7046bd9465ee965fb5666d1ffe28",
+  "baseline-sha": "24571476c68f47e2acdd0f0ed918f0b2cb584e04",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.5.0",
-      "tag": "v0.5.0"
+      "version": "0.6.0",
+      "tag": "v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.5.0",
-      "tag": "badness-code-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-code-v0.6.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.5.0",
-      "tag": "v0.5.0"
+      "version": "0.6.0",
+      "tag": "v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.5.0",
-      "tag": "badness-code-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-code-v0.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/badness/compare/v0.5.0...v0.6.0) (2026-07-06)
+
+### Features
+- **completion:** complete `\usepackage`/`\documentclass` names ([`2457147`](https://github.com/jolars/badness/commit/24571476c68f47e2acdd0f0ed918f0b2cb584e04))
+- **completion:** add baked package/class name lists ([`ff4906d`](https://github.com/jolars/badness/commit/ff4906dfd2e4dbf3aa2830eb382c63284429cf69))
+- **lsp:** add document links ([`915aea6`](https://github.com/jolars/badness/commit/915aea6402fa4813c5eae383548d300b1f3610da))
+- **lsp:** highlight matching `\begin`/`\end` pair ([`d643518`](https://github.com/jolars/badness/commit/d64351844066b7232c71460528b7391e3a538b28))
+- **lsp:** re-indent on close via onTypeFormatting ([`5972340`](https://github.com/jolars/badness/commit/5972340cb4d8bb1bc9972f55b559e4211f1e7228))
+- **parser:** parse math environments in math mode ([`9097be3`](https://github.com/jolars/badness/commit/9097be3717c025b73bcc528dc2ac35b13bcd6b94))
+- **formatter:** implement sentence and semantic wrap modes ([`17003ba`](https://github.com/jolars/badness/commit/17003bace4b7a40505361adfbd6545b58ee66b6d))
+- **linter:** add hard-coded-reference rule ([`da66c29`](https://github.com/jolars/badness/commit/da66c298c385142a76970b91a61e322f11e2b765))
+- **linter:** add sectioning-level-jump rule ([`6ac6def`](https://github.com/jolars/badness/commit/6ac6defb60760c257f51ab2e7f22884ac3fc2b0d))
+- **linter:** add makeat-macro rule ([`2ae6d07`](https://github.com/jolars/badness/commit/2ae6d075ab6ab01e7efe44cad5f538c4292f7fd2))
+- **linter:** add space-before-command rule ([`36d5fa3`](https://github.com/jolars/badness/commit/36d5fa3c47af7939bcbacba8911bab3ca118b485))
+- **linter:** add abbreviation-spacing rule ([`2fea8db`](https://github.com/jolars/badness/commit/2fea8db340303dbb5f640adc7fc5ddc83aacfd74))
+- **linter:** add swallowed-space rule ([`c48aa20`](https://github.com/jolars/badness/commit/c48aa20ce6f59df9cca16959417abf6938f1a5b3))
+- **linter:** add primitive-command rule ([`94da7ca`](https://github.com/jolars/badness/commit/94da7cacda77e12ed0da2fa323738920fe681fdf))
+- **linter:** add math-operator-name rule ([`17cc5f2`](https://github.com/jolars/badness/commit/17cc5f2e175315d5686d0f9ed1cea781e48f82f3))
+- **linter:** add times-variable rule ([`52de07a`](https://github.com/jolars/badness/commit/52de07ac61fb5222ef4b4d1a3c0cd0631c40ebd3))
+- **linter:** add dash-length rule ([`a6218e0`](https://github.com/jolars/badness/commit/a6218e0aadde3694786f58132104b5d23fd8c5c6))
+- **linter:** add straight-quotes rule for ASCII quotes ([`adff4ba`](https://github.com/jolars/badness/commit/adff4bafdfa91f6e8f2f0598e32430248b48d9cb))
+- **linter:** add ellipsis rule for literal ... ([`488ebdd`](https://github.com/jolars/badness/commit/488ebddc399f91acc29f5cb38aa851ac962afd57))
+- **linter:** generate rules reference from metadata ([`74e2234`](https://github.com/jolars/badness/commit/74e223425ada75b25e3558903784cf2cf2a9c438))
+- **math:** normalize operator spacing ([`36c9314`](https://github.com/jolars/badness/commit/36c9314b3017366879160a385a67e83f3bdcbead))
+- **semantic:** keep built-in over delegating arity-0 redef ([`9fd50d8`](https://github.com/jolars/badness/commit/9fd50d8f74f661dffa8f9e3bbb6c58494d2453df))
+- add title, author, date, thanks to signatures db ([`3c537d1`](https://github.com/jolars/badness/commit/3c537d1b3b4af9f1f7ce1abd6a06914504dd03a8))
+- **formatter:** stack binary chains under the relation too ([`0777920`](https://github.com/jolars/badness/commit/077792009dc99f761a0046012cffdb8bdf8e04b6))
+- **formatter:** align relation chains in display math ([`e69a72e`](https://github.com/jolars/badness/commit/e69a72ee540ab9af778cbd7246d0e09351d7bc82))
+- **formatter:** join alignment-cell continuation lines ([`cd3e590`](https://github.com/jolars/badness/commit/cd3e5907c7b629348222306badce7501aadb4f41))
+- **semantic:** resolve packages to .dtx sources ([`249e68e`](https://github.com/jolars/badness/commit/249e68e63bc91844a863e123767e06d2daf5aed9))
+
+### Bug Fixes
+- **parser:** point unclosed-delimiter errors at the opener ([`1029351`](https://github.com/jolars/badness/commit/10293517fb100519c84cb830b446327be06ded8e))
+- **formatter:** tight spacing and no paren breaks in display math ([`7112b8c`](https://github.com/jolars/badness/commit/7112b8cd9b4b6e0d9d5e230b9fe75c8a587079d7))
+- **linter:** allow en dash between proper names in dash-length ([`2ab4342`](https://github.com/jolars/badness/commit/2ab4342147279ec63c86b5f26e53a8749805ec9d))
+- **formatter:** peel over-attached cell off table rules ([`7c91ac9`](https://github.com/jolars/badness/commit/7c91ac97cd1ff7e74b4c4a629ef4dab713307334))
+
+### Reverts
+- "feat(formatter): stack binary chains under the relation too" ([`4a6988b`](https://github.com/jolars/badness/commit/4a6988bbebf2257a4cdf2c05c86c33bd561fd7be))
+
 ## [0.5.0](https://github.com/jolars/badness/compare/v0.4.0...v0.5.0) (2026-07-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -256,9 +256,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -341,7 +341,7 @@ version = "0.0.0"
 source = "git+https://github.com/latex-lsp/texlab?rev=adc91ff8a3b56ba4b72c489db33f32cfbb8b2c5c#adc91ff8a3b56ba4b72c489db33f32cfbb8b2c5c"
 dependencies = [
  "anyhow",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -557,9 +557,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -722,7 +722,7 @@ dependencies = [
  "pathdiff",
  "regex",
  "rowan",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "shellexpand",
  "syntax",
  "tempfile",
@@ -905,9 +905,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -954,7 +954,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",
@@ -1138,7 +1138,7 @@ dependencies = [
  "distro",
  "itertools",
  "rowan",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/badness/compare/badness-code-v0.5.0...badness-code-v0.6.0) (2026-07-06)
+
+### Dependencies
+- updated badness to v0.6.0
+
 ## [0.5.0](https://github.com/jolars/badness/compare/badness-code-v0.4.0...badness-code-v0.5.0) (2026-07-01)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.5.0",
-    "@badness/linux-arm64-gnu": "0.5.0",
-    "@badness/linux-x64-musl": "0.5.0",
-    "@badness/linux-arm64-musl": "0.5.0",
-    "@badness/darwin-x64": "0.5.0",
-    "@badness/darwin-arm64": "0.5.0",
-    "@badness/win32-x64": "0.5.0",
-    "@badness/win32-arm64": "0.5.0"
+    "@badness/linux-x64-gnu": "0.6.0",
+    "@badness/linux-arm64-gnu": "0.6.0",
+    "@badness/linux-x64-musl": "0.6.0",
+    "@badness/linux-arm64-musl": "0.6.0",
+    "@badness/darwin-x64": "0.6.0",
+    "@badness/darwin-arm64": "0.6.0",
+    "@badness/win32-x64": "0.6.0",
+    "@badness/win32-arm64": "0.6.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.6.0](https://github.com/jolars/badness/compare/v0.5.0...v0.6.0) (2026-07-06)

### Features
- **completion:** complete `\usepackage`/`\documentclass` names ([`2457147`](https://github.com/jolars/badness/commit/24571476c68f47e2acdd0f0ed918f0b2cb584e04))
- **completion:** add baked package/class name lists ([`ff4906d`](https://github.com/jolars/badness/commit/ff4906dfd2e4dbf3aa2830eb382c63284429cf69))
- **lsp:** add document links ([`915aea6`](https://github.com/jolars/badness/commit/915aea6402fa4813c5eae383548d300b1f3610da))
- **lsp:** highlight matching `\begin`/`\end` pair ([`d643518`](https://github.com/jolars/badness/commit/d64351844066b7232c71460528b7391e3a538b28))
- **lsp:** re-indent on close via onTypeFormatting ([`5972340`](https://github.com/jolars/badness/commit/5972340cb4d8bb1bc9972f55b559e4211f1e7228))
- **parser:** parse math environments in math mode ([`9097be3`](https://github.com/jolars/badness/commit/9097be3717c025b73bcc528dc2ac35b13bcd6b94))
- **formatter:** implement sentence and semantic wrap modes ([`17003ba`](https://github.com/jolars/badness/commit/17003bace4b7a40505361adfbd6545b58ee66b6d))
- **linter:** add hard-coded-reference rule ([`da66c29`](https://github.com/jolars/badness/commit/da66c298c385142a76970b91a61e322f11e2b765))
- **linter:** add sectioning-level-jump rule ([`6ac6def`](https://github.com/jolars/badness/commit/6ac6defb60760c257f51ab2e7f22884ac3fc2b0d))
- **linter:** add makeat-macro rule ([`2ae6d07`](https://github.com/jolars/badness/commit/2ae6d075ab6ab01e7efe44cad5f538c4292f7fd2))
- **linter:** add space-before-command rule ([`36d5fa3`](https://github.com/jolars/badness/commit/36d5fa3c47af7939bcbacba8911bab3ca118b485))
- **linter:** add abbreviation-spacing rule ([`2fea8db`](https://github.com/jolars/badness/commit/2fea8db340303dbb5f640adc7fc5ddc83aacfd74))
- **linter:** add swallowed-space rule ([`c48aa20`](https://github.com/jolars/badness/commit/c48aa20ce6f59df9cca16959417abf6938f1a5b3))
- **linter:** add primitive-command rule ([`94da7ca`](https://github.com/jolars/badness/commit/94da7cacda77e12ed0da2fa323738920fe681fdf))
- **linter:** add math-operator-name rule ([`17cc5f2`](https://github.com/jolars/badness/commit/17cc5f2e175315d5686d0f9ed1cea781e48f82f3))
- **linter:** add times-variable rule ([`52de07a`](https://github.com/jolars/badness/commit/52de07ac61fb5222ef4b4d1a3c0cd0631c40ebd3))
- **linter:** add dash-length rule ([`a6218e0`](https://github.com/jolars/badness/commit/a6218e0aadde3694786f58132104b5d23fd8c5c6))
- **linter:** add straight-quotes rule for ASCII quotes ([`adff4ba`](https://github.com/jolars/badness/commit/adff4bafdfa91f6e8f2f0598e32430248b48d9cb))
- **linter:** add ellipsis rule for literal ... ([`488ebdd`](https://github.com/jolars/badness/commit/488ebddc399f91acc29f5cb38aa851ac962afd57))
- **linter:** generate rules reference from metadata ([`74e2234`](https://github.com/jolars/badness/commit/74e223425ada75b25e3558903784cf2cf2a9c438))
- **math:** normalize operator spacing ([`36c9314`](https://github.com/jolars/badness/commit/36c9314b3017366879160a385a67e83f3bdcbead))
- **semantic:** keep built-in over delegating arity-0 redef ([`9fd50d8`](https://github.com/jolars/badness/commit/9fd50d8f74f661dffa8f9e3bbb6c58494d2453df))
- add title, author, date, thanks to signatures db ([`3c537d1`](https://github.com/jolars/badness/commit/3c537d1b3b4af9f1f7ce1abd6a06914504dd03a8))
- **formatter:** stack binary chains under the relation too ([`0777920`](https://github.com/jolars/badness/commit/077792009dc99f761a0046012cffdb8bdf8e04b6))
- **formatter:** align relation chains in display math ([`e69a72e`](https://github.com/jolars/badness/commit/e69a72ee540ab9af778cbd7246d0e09351d7bc82))
- **formatter:** join alignment-cell continuation lines ([`cd3e590`](https://github.com/jolars/badness/commit/cd3e5907c7b629348222306badce7501aadb4f41))
- **semantic:** resolve packages to .dtx sources ([`249e68e`](https://github.com/jolars/badness/commit/249e68e63bc91844a863e123767e06d2daf5aed9))

### Bug Fixes
- **parser:** point unclosed-delimiter errors at the opener ([`1029351`](https://github.com/jolars/badness/commit/10293517fb100519c84cb830b446327be06ded8e))
- **formatter:** tight spacing and no paren breaks in display math ([`7112b8c`](https://github.com/jolars/badness/commit/7112b8cd9b4b6e0d9d5e230b9fe75c8a587079d7))
- **linter:** allow en dash between proper names in dash-length ([`2ab4342`](https://github.com/jolars/badness/commit/2ab4342147279ec63c86b5f26e53a8749805ec9d))
- **formatter:** peel over-attached cell off table rules ([`7c91ac9`](https://github.com/jolars/badness/commit/7c91ac97cd1ff7e74b4c4a629ef4dab713307334))

### Reverts
- "feat(formatter): stack binary chains under the relation too" ([`4a6988b`](https://github.com/jolars/badness/commit/4a6988bbebf2257a4cdf2c05c86c33bd561fd7be))

## [editors/code: 0.6.0](https://github.com/jolars/badness/compare/badness-code-v0.5.0...badness-code-v0.6.0) (2026-07-06)

### Dependencies
- updated badness to v0.6.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).