### PR TITLE
chore(release): v0.7.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "24571476c68f47e2acdd0f0ed918f0b2cb584e04",
+  "baseline-sha": "d38b4d6bc2b2899a25b0b5ad970895b438d5e9da",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.6.0",
-      "tag": "v0.6.0"
+      "version": "0.7.0",
+      "tag": "v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.6.0",
-      "tag": "badness-code-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-code-v0.7.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.6.0",
-      "tag": "v0.6.0"
+      "version": "0.7.0",
+      "tag": "v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.6.0",
-      "tag": "badness-code-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-code-v0.7.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/badness/compare/v0.6.0...v0.7.0) (2026-07-08)
+
+### Features
+- **lsp:** selection ranges from CST hierarchy ([`2aff55f`](https://github.com/jolars/badness/commit/2aff55f151c5b4b593b62dfa9e3f817ea5602db0))
+- **formatter:** column-spec-aware table alignment ([`9ab94ba`](https://github.com/jolars/badness/commit/9ab94ba19ce8c34f13cff42dd248d78a570961c0))
+- **linter:** package-aware duplicate and provides lints ([`758fac3`](https://github.com/jolars/badness/commit/758fac39180017423444d2ba57ca9d38031734b4))
+- **semantic:** recognize package metadata and options ([`0cd95ce`](https://github.com/jolars/badness/commit/0cd95ce51a58c87a19b6c9564d2e6eea3307f476))
+- **lsp:** color and TikZ/PGF library completion ([`1a881f3`](https://github.com/jolars/badness/commit/1a881f33a598be78e6e196ac53733c2b584bcbed))
+- **lint:** add unreferenced-label rule ([`4d975a1`](https://github.com/jolars/badness/commit/4d975a1560b8a67b6befb505f1470657f30dee30))
+- **lint:** add verbatim-trailing-text rule ([`a11358d`](https://github.com/jolars/badness/commit/a11358dff3bcd09b2d27c8ae373bd6e190dc1aa5))
+- **lint:** flag line-break tie in missing-nonbreaking-space ([`de2d51f`](https://github.com/jolars/badness/commit/de2d51fb1db7d0c53d6f868cec13bff51f4df6c7))
+- **lint:** autofix obsolete-environment eqnarray to align ([`aa26b13`](https://github.com/jolars/badness/commit/aa26b138e3f19a83f42541401de20d4b1bf1690e))
+- **lint:** add missing-required-argument rule ([`5206ee6`](https://github.com/jolars/badness/commit/5206ee66e6b683b371c0fc670440bb981e92ceec))
+- **lsp:** references, rename, goto-def for user macros ([`fdeb0e9`](https://github.com/jolars/badness/commit/fdeb0e9b3f2c35076656b61b1022b7ffcf7865ab))
+- **lsp:** negotiate client capabilities at initialize ([`36b6ed2`](https://github.com/jolars/badness/commit/36b6ed29d40f61839ccc43ec8f5657a10d27b50d))
+- **lsp:** change-environment refactor command ([`1f27fab`](https://github.com/jolars/badness/commit/1f27fab4ccc37022555588dac39fe56566afefb7))
+- **lsp:** glossary/acronym key completion ([`f73f138`](https://github.com/jolars/badness/commit/f73f138c46fbb8982aa580528114be70e28f2c75))
+- **lsp:** signature help for command arguments ([`0c5f649`](https://github.com/jolars/badness/commit/0c5f6491d7b377db7e04da2daacbbaa8476c5b75))
+- **lsp:** label hover and symbol numbers from `.aux` ([`3efb7aa`](https://github.com/jolars/badness/commit/3efb7aa4d7afc64ecb3ba340097d3f78997062ce))
+- **semantic:** classify what a `\label` labels ([`01a8b0b`](https://github.com/jolars/badness/commit/01a8b0b76b408c5d0da48a75dfeedb67a1bf8697))
+- **project:** scan `.aux` for label numbers and toc ([`ed48898`](https://github.com/jolars/badness/commit/ed4889826dd9be877a8eef425060c3186b5e9f82))
+- **config:** add `[build]` section with `aux-dir` ([`ad8cc8a`](https://github.com/jolars/badness/commit/ad8cc8a80bc8932feb01844616f776aec273afa7))
+- **lsp:** go-to-definition for include/package file arguments ([`99927ea`](https://github.com/jolars/badness/commit/99927ea832d901f4c8810f0611cd4350e3871bea))
+- **lsp:** resolve packages via TEXMF index and CTAN metadata ([`24ba5c7`](https://github.com/jolars/badness/commit/24ba5c73c955544471a29553a97f91695b0ae48a))
+
+### Bug Fixes
+- **bib:** tighten title-capitalization camelCase heuristic ([`91de065`](https://github.com/jolars/badness/commit/91de06585001800aab0bf3ff2b91b3e126e7c244))
+- **ci:** rename aux.rs, allow option-ext MPL-2.0 ([`cc1c834`](https://github.com/jolars/badness/commit/cc1c8348058f6b1856af98874e1d77163c12f882))
+
+### Performance Improvements
+- **formatter:** parallelize the CLI format paths ([`d38b4d6`](https://github.com/jolars/badness/commit/d38b4d6bc2b2899a25b0b5ad970895b438d5e9da))
+- **linter:** cache registry, stream rewalkers, parallelize CLI ([`5c3813a`](https://github.com/jolars/badness/commit/5c3813a298d4c2c3e1e9771b806385c5be6d6a74))
+- **signature:** bake CTAN metadata via phf, not runtime parse ([`f635d23`](https://github.com/jolars/badness/commit/f635d23f215516269485b9fbfc73a289e84c0317))
+
 ## [0.6.0](https://github.com/jolars/badness/compare/v0.5.0...v0.6.0) (2026-07-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -275,18 +275,18 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -303,18 +303,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "dirs"
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "mdbook-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc1c4da7fd9e2e412f3891428f9468fab890ed159723ed0892bb85a049ac1c1"
+checksum = "8725b7f8e94a5c40a00c907e4006301ba2fc06722de489a0cb19db1823fdf200"
 dependencies = [
  "anyhow",
  "regex",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-preprocessor"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eff7b4afaafd664a649a03b8891ad8199aef359a35b911ad6c31acab38ed209"
+checksum = "f8e75b08763e31982701d5b2680124bd4bd9bed4a4e1b5a499381320ccae199f"
 dependencies = [
  "anyhow",
  "mdbook-core",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "once_cell"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/badness/compare/badness-code-v0.6.0...badness-code-v0.7.0) (2026-07-08)
+
+### Dependencies
+- updated badness to v0.7.0
+
 ## [0.6.0](https://github.com/jolars/badness/compare/badness-code-v0.5.0...badness-code-v0.6.0) (2026-07-06)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.6.0",
-    "@badness/linux-arm64-gnu": "0.6.0",
-    "@badness/linux-x64-musl": "0.6.0",
-    "@badness/linux-arm64-musl": "0.6.0",
-    "@badness/darwin-x64": "0.6.0",
-    "@badness/darwin-arm64": "0.6.0",
-    "@badness/win32-x64": "0.6.0",
-    "@badness/win32-arm64": "0.6.0"
+    "@badness/linux-x64-gnu": "0.7.0",
+    "@badness/linux-arm64-gnu": "0.7.0",
+    "@badness/linux-x64-musl": "0.7.0",
+    "@badness/linux-arm64-musl": "0.7.0",
+    "@badness/darwin-x64": "0.7.0",
+    "@badness/darwin-arm64": "0.7.0",
+    "@badness/win32-x64": "0.7.0",
+    "@badness/win32-arm64": "0.7.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.7.0](https://github.com/jolars/badness/compare/v0.6.0...v0.7.0) (2026-07-08)

### Features
- **lsp:** selection ranges from CST hierarchy ([`2aff55f`](https://github.com/jolars/badness/commit/2aff55f151c5b4b593b62dfa9e3f817ea5602db0))
- **formatter:** column-spec-aware table alignment ([`9ab94ba`](https://github.com/jolars/badness/commit/9ab94ba19ce8c34f13cff42dd248d78a570961c0))
- **linter:** package-aware duplicate and provides lints ([`758fac3`](https://github.com/jolars/badness/commit/758fac39180017423444d2ba57ca9d38031734b4))
- **semantic:** recognize package metadata and options ([`0cd95ce`](https://github.com/jolars/badness/commit/0cd95ce51a58c87a19b6c9564d2e6eea3307f476))
- **lsp:** color and TikZ/PGF library completion ([`1a881f3`](https://github.com/jolars/badness/commit/1a881f33a598be78e6e196ac53733c2b584bcbed))
- **lint:** add unreferenced-label rule ([`4d975a1`](https://github.com/jolars/badness/commit/4d975a1560b8a67b6befb505f1470657f30dee30))
- **lint:** add verbatim-trailing-text rule ([`a11358d`](https://github.com/jolars/badness/commit/a11358dff3bcd09b2d27c8ae373bd6e190dc1aa5))
- **lint:** flag line-break tie in missing-nonbreaking-space ([`de2d51f`](https://github.com/jolars/badness/commit/de2d51fb1db7d0c53d6f868cec13bff51f4df6c7))
- **lint:** autofix obsolete-environment eqnarray to align ([`aa26b13`](https://github.com/jolars/badness/commit/aa26b138e3f19a83f42541401de20d4b1bf1690e))
- **lint:** add missing-required-argument rule ([`5206ee6`](https://github.com/jolars/badness/commit/5206ee66e6b683b371c0fc670440bb981e92ceec))
- **lsp:** references, rename, goto-def for user macros ([`fdeb0e9`](https://github.com/jolars/badness/commit/fdeb0e9b3f2c35076656b61b1022b7ffcf7865ab))
- **lsp:** negotiate client capabilities at initialize ([`36b6ed2`](https://github.com/jolars/badness/commit/36b6ed29d40f61839ccc43ec8f5657a10d27b50d))
- **lsp:** change-environment refactor command ([`1f27fab`](https://github.com/jolars/badness/commit/1f27fab4ccc37022555588dac39fe56566afefb7))
- **lsp:** glossary/acronym key completion ([`f73f138`](https://github.com/jolars/badness/commit/f73f138c46fbb8982aa580528114be70e28f2c75))
- **lsp:** signature help for command arguments ([`0c5f649`](https://github.com/jolars/badness/commit/0c5f6491d7b377db7e04da2daacbbaa8476c5b75))
- **lsp:** label hover and symbol numbers from `.aux` ([`3efb7aa`](https://github.com/jolars/badness/commit/3efb7aa4d7afc64ecb3ba340097d3f78997062ce))
- **semantic:** classify what a `\label` labels ([`01a8b0b`](https://github.com/jolars/badness/commit/01a8b0b76b408c5d0da48a75dfeedb67a1bf8697))
- **project:** scan `.aux` for label numbers and toc ([`ed48898`](https://github.com/jolars/badness/commit/ed4889826dd9be877a8eef425060c3186b5e9f82))
- **config:** add `[build]` section with `aux-dir` ([`ad8cc8a`](https://github.com/jolars/badness/commit/ad8cc8a80bc8932feb01844616f776aec273afa7))
- **lsp:** go-to-definition for include/package file arguments ([`99927ea`](https://github.com/jolars/badness/commit/99927ea832d901f4c8810f0611cd4350e3871bea))
- **lsp:** resolve packages via TEXMF index and CTAN metadata ([`24ba5c7`](https://github.com/jolars/badness/commit/24ba5c73c955544471a29553a97f91695b0ae48a))

### Bug Fixes
- **bib:** tighten title-capitalization camelCase heuristic ([`91de065`](https://github.com/jolars/badness/commit/91de06585001800aab0bf3ff2b91b3e126e7c244))
- **ci:** rename aux.rs, allow option-ext MPL-2.0 ([`cc1c834`](https://github.com/jolars/badness/commit/cc1c8348058f6b1856af98874e1d77163c12f882))

### Performance Improvements
- **formatter:** parallelize the CLI format paths ([`d38b4d6`](https://github.com/jolars/badness/commit/d38b4d6bc2b2899a25b0b5ad970895b438d5e9da))
- **linter:** cache registry, stream rewalkers, parallelize CLI ([`5c3813a`](https://github.com/jolars/badness/commit/5c3813a298d4c2c3e1e9771b806385c5be6d6a74))
- **signature:** bake CTAN metadata via phf, not runtime parse ([`f635d23`](https://github.com/jolars/badness/commit/f635d23f215516269485b9fbfc73a289e84c0317))

## [editors/code: 0.7.0](https://github.com/jolars/badness/compare/badness-code-v0.6.0...badness-code-v0.7.0) (2026-07-08)

### Dependencies
- updated badness to v0.7.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).