### PR TITLE
chore(release): v0.8.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d38b4d6bc2b2899a25b0b5ad970895b438d5e9da",
+  "baseline-sha": "ddb43d22688d47d5cf2a66717eec3c91206d0a99",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.7.0",
-      "tag": "v0.7.0"
+      "version": "0.8.0",
+      "tag": "v0.8.0"
     },
     {
       "path": "editors/code",
-      "version": "0.7.0",
-      "tag": "badness-code-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-code-v0.8.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.7.0",
-      "tag": "v0.7.0"
+      "version": "0.8.0",
+      "tag": "v0.8.0"
     },
     {
       "path": "editors/code",
-      "version": "0.7.0",
-      "tag": "badness-code-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-code-v0.8.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/badness/compare/v0.7.0...v0.8.0) (2026-07-11)
+
+### Features
+- **lsp:** show source package in macro hover ([`eaf030e`](https://github.com/jolars/badness/commit/eaf030ea9da011ce90b77b64f37155ffab5da665))
+- **lint:** add `unknown-option` rule for local packages ([`f040033`](https://github.com/jolars/badness/commit/f040033e049acb340f27e66eba1eeecc70f68a33))
+- **bib:** document links for doi and url fields ([`e1f15f7`](https://github.com/jolars/badness/commit/e1f15f7f8d0b1afe265f1a5c40f7a28f88437b8f))
+- **completion:** argument-value enum completion ([`f363499`](https://github.com/jolars/badness/commit/f36349970afdb020af52e368051db11d3331b58b))
+- **bench:** add linter speed benchmark vs lacheck and chktex ([`e6a821e`](https://github.com/jolars/badness/commit/e6a821ed159211081fce7030bef567d4f7ae371e))
+- **bench:** add whole-project folder benchmark ([`620c7cc`](https://github.com/jolars/badness/commit/620c7cc5202b47c017ab4135184cd8d54ad5ba76))
+- **bib:** typed AST wrapper layer for BibTeX CST ([`0abe33a`](https://github.com/jolars/badness/commit/0abe33ac3f68f77c390328fc2d7da804cd235f39))
+- **ast:** typed AstNode/AstToken wrapper layer ([`35eae44`](https://github.com/jolars/badness/commit/35eae44b0fd70850aa1e02e8204c098479e6d391))
+
+### Performance Improvements
+- **cli:** parallelize lint --fix across files ([`133a4c3`](https://github.com/jolars/badness/commit/133a4c39ff6a34665e5fa6552cc13f9dc7253a23))
+
 ## [0.7.0](https://github.com/jolars/badness/compare/v0.6.0...v0.7.0) (2026-07-08)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -470,9 +470,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/badness/compare/badness-code-v0.7.0...badness-code-v0.8.0) (2026-07-11)
+
+### Dependencies
+- updated badness to v0.8.0
+
 ## [0.7.0](https://github.com/jolars/badness/compare/badness-code-v0.6.0...badness-code-v0.7.0) (2026-07-08)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.7.0",
-    "@badness/linux-arm64-gnu": "0.7.0",
-    "@badness/linux-x64-musl": "0.7.0",
-    "@badness/linux-arm64-musl": "0.7.0",
-    "@badness/darwin-x64": "0.7.0",
-    "@badness/darwin-arm64": "0.7.0",
-    "@badness/win32-x64": "0.7.0",
-    "@badness/win32-arm64": "0.7.0"
+    "@badness/linux-x64-gnu": "0.8.0",
+    "@badness/linux-arm64-gnu": "0.8.0",
+    "@badness/linux-x64-musl": "0.8.0",
+    "@badness/linux-arm64-musl": "0.8.0",
+    "@badness/darwin-x64": "0.8.0",
+    "@badness/darwin-arm64": "0.8.0",
+    "@badness/win32-x64": "0.8.0",
+    "@badness/win32-arm64": "0.8.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.8.0](https://github.com/jolars/badness/compare/v0.7.0...v0.8.0) (2026-07-11)

### Features
- **lsp:** show source package in macro hover ([`eaf030e`](https://github.com/jolars/badness/commit/eaf030ea9da011ce90b77b64f37155ffab5da665))
- **lint:** add `unknown-option` rule for local packages ([`f040033`](https://github.com/jolars/badness/commit/f040033e049acb340f27e66eba1eeecc70f68a33))
- **bib:** document links for doi and url fields ([`e1f15f7`](https://github.com/jolars/badness/commit/e1f15f7f8d0b1afe265f1a5c40f7a28f88437b8f))
- **completion:** argument-value enum completion ([`f363499`](https://github.com/jolars/badness/commit/f36349970afdb020af52e368051db11d3331b58b))
- **bench:** add linter speed benchmark vs lacheck and chktex ([`e6a821e`](https://github.com/jolars/badness/commit/e6a821ed159211081fce7030bef567d4f7ae371e))
- **bench:** add whole-project folder benchmark ([`620c7cc`](https://github.com/jolars/badness/commit/620c7cc5202b47c017ab4135184cd8d54ad5ba76))
- **bib:** typed AST wrapper layer for BibTeX CST ([`0abe33a`](https://github.com/jolars/badness/commit/0abe33ac3f68f77c390328fc2d7da804cd235f39))
- **ast:** typed AstNode/AstToken wrapper layer ([`35eae44`](https://github.com/jolars/badness/commit/35eae44b0fd70850aa1e02e8204c098479e6d391))

### Performance Improvements
- **cli:** parallelize lint --fix across files ([`133a4c3`](https://github.com/jolars/badness/commit/133a4c39ff6a34665e5fa6552cc13f9dc7253a23))

## [editors/code: 0.8.0](https://github.com/jolars/badness/compare/badness-code-v0.7.0...badness-code-v0.8.0) (2026-07-11)

### Dependencies
- updated badness to v0.8.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).