### PR TITLE
chore(release): v0.9.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ddb43d22688d47d5cf2a66717eec3c91206d0a99",
+  "baseline-sha": "7f52ef54bae11135d0e073978e73b25252f01d86",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.8.0",
-      "tag": "v0.8.0"
+      "version": "0.9.0",
+      "tag": "v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.8.0",
-      "tag": "badness-code-v0.8.0"
+      "version": "0.9.0",
+      "tag": "badness-code-v0.9.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.8.0",
-      "tag": "v0.8.0"
+      "version": "0.9.0",
+      "tag": "v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.8.0",
-      "tag": "badness-code-v0.8.0"
+      "version": "0.9.0",
+      "tag": "badness-code-v0.9.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/badness/compare/v0.8.0...v0.9.0) (2026-07-14)
+
+### Features
+- **linter:** make fixes carry multiple atomic edits ([`7f52ef5`](https://github.com/jolars/badness/commit/7f52ef54bae11135d0e073978e73b25252f01d86))
+- **linter:** add diagnostic related information ([`ada447b`](https://github.com/jolars/badness/commit/ada447bc4afe3001d1bafe96c5c759e240d5b1f8))
+- **parser:** add a release-mode stuck-loop step limiter ([`f93b1e5`](https://github.com/jolars/badness/commit/f93b1e5043125802a77da462e8305b8748a25036))
+- **lsp:** add diagnostic tags and rule doc links ([`906b0df`](https://github.com/jolars/badness/commit/906b0dfbd43477f8320a06dd1f4807207bfd7e66))
+
+### Bug Fixes
+- **lsp:** recover poisoned db mutexes instead of panicking ([`5844ff2`](https://github.com/jolars/badness/commit/5844ff2c029b207cf8e9fa55124d68ca831c953c))
+- **bib:** resolve field aliases in missing-required check ([`f20283b`](https://github.com/jolars/badness/commit/f20283baabca65eeaadf447ef80bba7ded5de81e))
+
 ## [0.8.0](https://github.com/jolars/badness/compare/v0.7.0...v0.8.0) (2026-07-11)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1310,12 +1310,12 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
 ]
 
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -243,7 +243,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -270,14 +270,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -324,12 +324,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/badness/compare/badness-code-v0.8.0...badness-code-v0.9.0) (2026-07-14)
+
+### Dependencies
+- updated badness to v0.9.0
+
 ## [0.8.0](https://github.com/jolars/badness/compare/badness-code-v0.7.0...badness-code-v0.8.0) (2026-07-11)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.8.0",
-    "@badness/linux-arm64-gnu": "0.8.0",
-    "@badness/linux-x64-musl": "0.8.0",
-    "@badness/linux-arm64-musl": "0.8.0",
-    "@badness/darwin-x64": "0.8.0",
-    "@badness/darwin-arm64": "0.8.0",
-    "@badness/win32-x64": "0.8.0",
-    "@badness/win32-arm64": "0.8.0"
+    "@badness/linux-x64-gnu": "0.9.0",
+    "@badness/linux-arm64-gnu": "0.9.0",
+    "@badness/linux-x64-musl": "0.9.0",
+    "@badness/linux-arm64-musl": "0.9.0",
+    "@badness/darwin-x64": "0.9.0",
+    "@badness/darwin-arm64": "0.9.0",
+    "@badness/win32-x64": "0.9.0",
+    "@badness/win32-arm64": "0.9.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.9.0](https://github.com/jolars/badness/compare/v0.8.0...v0.9.0) (2026-07-14)

### Features
- **linter:** make fixes carry multiple atomic edits ([`7f52ef5`](https://github.com/jolars/badness/commit/7f52ef54bae11135d0e073978e73b25252f01d86))
- **linter:** add diagnostic related information ([`ada447b`](https://github.com/jolars/badness/commit/ada447bc4afe3001d1bafe96c5c759e240d5b1f8))
- **parser:** add a release-mode stuck-loop step limiter ([`f93b1e5`](https://github.com/jolars/badness/commit/f93b1e5043125802a77da462e8305b8748a25036))
- **lsp:** add diagnostic tags and rule doc links ([`906b0df`](https://github.com/jolars/badness/commit/906b0dfbd43477f8320a06dd1f4807207bfd7e66))

### Bug Fixes
- **lsp:** recover poisoned db mutexes instead of panicking ([`5844ff2`](https://github.com/jolars/badness/commit/5844ff2c029b207cf8e9fa55124d68ca831c953c))
- **bib:** resolve field aliases in missing-required check ([`f20283b`](https://github.com/jolars/badness/commit/f20283baabca65eeaadf447ef80bba7ded5de81e))

## [editors/code: 0.9.0](https://github.com/jolars/badness/compare/badness-code-v0.8.0...badness-code-v0.9.0) (2026-07-14)

### Dependencies
- updated badness to v0.9.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).