### PR TITLE
fix(linter): target the whole construct for DOC_COMMENT-bound suppressions

### DIFF
--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -177,6 +177,30 @@ mod tests {
     }
 
     #[test]
+    fn node_directive_suppresses_construct_with_arguments() {
+        // Regression: a comment immediately before a bare `\command` (no
+        // enclosing group) binds into a `DOC_COMMENT` that is the *leading
+        // child* of the `COMMAND` node, not a preceding sibling of it.
+        let out = lint(
+            "\\usepackage{amsmath}\n\
+             % badness-ignore duplicate-package: legacy, loaded twice on purpose\n\
+             \\usepackage{amsmath}\n",
+        );
+        assert!(out.is_empty(), "expected suppression, got: {out:?}");
+    }
+
+    #[test]
+    fn node_directive_suppresses_diagnostic_inside_argument() {
+        // Regression: same root cause as above, from the other direction -
+        // `dash-length` flags a token *inside* `\cline{2-7}`'s argument group,
+        // a range the old walk never reached at all (it stopped at the
+        // `\cline` control word).
+        let out =
+            lint("% badness-ignore dash-length: interval, not a numeric range\n\\cline{2-7}\n");
+        assert!(out.is_empty(), "expected suppression, got: {out:?}");
+    }
+
+    #[test]
     fn file_directive_suppresses_all_occurrences() {
         let out = lint("% badness-ignore-file deprecated-command: legacy\n{\\bf x}\n{\\it y}\n");
         assert!(

--- a/src/linter/suppression.rs
+++ b/src/linter/suppression.rs
@@ -98,6 +98,19 @@ fn parse_rule(rest: &str) -> Option<String> {
 /// bubbling up through parents whose remaining siblings are all trivia (e.g. a
 /// comment on its own line under `ROOT`, whose target is the next block).
 fn next_meaningful_sibling(token: &SyntaxToken) -> Option<(usize, usize)> {
+    // A comment bound into a `DOC_COMMENT` node is always the *leading child*
+    // of the `COMMAND`/`ENVIRONMENT` construct it documents, not a sibling
+    // before it. Walking forward from the comment token only ever finds pieces
+    // *inside* that same construct (e.g. just its control word, missing the
+    // construct's own arguments), never the construct as a whole. Target the
+    // whole construct directly in that case.
+    if let Some(parent) = token.parent()
+        && parent.kind() == SyntaxKind::DOC_COMMENT
+    {
+        let construct = parent.parent()?;
+        let range = construct.text_range();
+        return Some((usize::from(range.start()), usize::from(range.end())));
+    }
     let mut current = token.clone();
     loop {
         let parent = current.parent()?;


### PR DESCRIPTION
`% badness-ignore` comments bound into a `DOC_COMMENT` node are always the leading child of the `COMMAND`/`ENVIRONMENT` they document, not a sibling before it. The suppression walk didn't account for this: it grabbed only the first child after the comment inside that construct (e.g. `\usepackage` itself), missing the construct's own arguments. Any diagnostic covering the whole command, or one nested inside its argument group, was never contained by the suppression range and fired anyway.

Special-case that shape to target the enclosing construct directly.

Added regression tests for both failure modes: a `duplicate-package` finding spanning the whole command, and a `dash-length` finding nested inside a `\cline{2-7}` argument.

Fixes #26

*Disclaimer: I used an AI agent to find the root cause of the issue*