### PR TITLE
chore(release): v0.11.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "aeab2e6cff44dc8ee6e906bc7b3b1704693cf882",
+  "baseline-sha": "fa4d20d4f8b46d76051d909e12eeda9b12b19c77",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "badness-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "badness-code-v0.11.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "badness-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "badness-code-v0.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/badness/compare/v0.10.0...v0.11.0) (2026-07-20)
+
+### Breaking changes
+- **lsp:** move texmf config to editor settings ([`2f83a84`](https://github.com/jolars/badness/commit/2f83a844a6876906e69843053cafb59ed6e5232b))
+
+### Features
+- **lsp:** move texmf config to editor settings ([`2f83a84`](https://github.com/jolars/badness/commit/2f83a844a6876906e69843053cafb59ed6e5232b))
+- **formatter:** hang nested blocks in align grids ([`5103bab`](https://github.com/jolars/badness/commit/5103babda2aa884f8dc5abe1b55a7fd2d3402fa5))
+- **linter:** document bib rules in --explain and docs ([`a2a742c`](https://github.com/jolars/badness/commit/a2a742ccd9db648ae60d90359a8118364fdd60b7)), closes [#24](https://github.com/jolars/badness/issues/24)
+
+### Bug Fixes
+- **tests:** adapt to `lsp-server` 0.10 `Response` API ([`5f1e889`](https://github.com/jolars/badness/commit/5f1e889969c92a4d2f58fc3d4fb6365ed6b696d2))
+- **linter:** skip script labels inside argument groups ([`1f8c0eb`](https://github.com/jolars/badness/commit/1f8c0ebed5e3ae93d617dc23195288446720ae46)), closes [#37](https://github.com/jolars/badness/issues/37)
+- **parser:** name blank line as math terminator ([`2751787`](https://github.com/jolars/badness/commit/2751787acad3f69588eb66dfc562bb293e743a7f)), ref [#35](https://github.com/jolars/badness/issues/35)
+- **linter:** ignore key arguments in dash-length ([`506e5f0`](https://github.com/jolars/badness/commit/506e5f0a365d1f5d988cdcd99706edab7ed435a8))
+- **linter:** ignore rule-command spans in dash-length ([`adeecf6`](https://github.com/jolars/badness/commit/adeecf69d79cfb38d52f4187184104385feaad71)), closes [#34](https://github.com/jolars/badness/issues/34)
+- **linter:** ignore key arguments in math-shape rules ([`387810a`](https://github.com/jolars/badness/commit/387810a7fbca8a9fd298634659c06dbb18ac0b6e)), closes [#25](https://github.com/jolars/badness/issues/25)
+- **parser:** keep unmatched `[` a plain atom in math ([`c185c13`](https://github.com/jolars/badness/commit/c185c1338aa830646db53c344dd2638240ebbb0f)), closes [#23](https://github.com/jolars/badness/issues/23)
+- **linter:** ignore labels in exclusive conditional branches ([`a6e0c22`](https://github.com/jolars/badness/commit/a6e0c228c177d25bd071a3ea8062ad8c9484c0aa))
+- **linter:** ignore package loads in exclusive branches ([`d16d3d1`](https://github.com/jolars/badness/commit/d16d3d1a71c3abe6bca1fb78ee46e18d3b8aff33)), closes [#27](https://github.com/jolars/badness/issues/27)
+- **linter:** target the whole construct for DOC_COMMENT-bound suppressions ([`cd647fa`](https://github.com/jolars/badness/commit/cd647fae218e61335ca080bda065d2c2b3425387)), fixes [#26](https://github.com/jolars/badness/issues/26)
+
 ## [0.10.0](https://github.com/jolars/badness/compare/v0.9.0...v0.10.0) (2026-07-15)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -140,9 +140,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -178,15 +178,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fluent-uri"
@@ -470,9 +470,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -784,24 +784,24 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1030,14 +1030,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1048,13 +1048,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1169,22 +1169,22 @@ checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "doc-utils"
@@ -102,18 +102,18 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -155,9 +155,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -165,29 +165,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -210,6 +210,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -298,7 +309,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/badness/compare/badness-code-v0.10.0...badness-code-v0.11.0) (2026-07-20)
+
+### Dependencies
+- updated badness to v0.11.0
+
 ## [0.10.0](https://github.com/jolars/badness/compare/badness-code-v0.9.0...badness-code-v0.10.0) (2026-07-15)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.10.0",
-    "@badness/linux-arm64-gnu": "0.10.0",
-    "@badness/linux-x64-musl": "0.10.0",
-    "@badness/linux-arm64-musl": "0.10.0",
-    "@badness/darwin-x64": "0.10.0",
-    "@badness/darwin-arm64": "0.10.0",
-    "@badness/win32-x64": "0.10.0",
-    "@badness/win32-arm64": "0.10.0"
+    "@badness/linux-x64-gnu": "0.11.0",
+    "@badness/linux-arm64-gnu": "0.11.0",
+    "@badness/linux-x64-musl": "0.11.0",
+    "@badness/linux-arm64-musl": "0.11.0",
+    "@badness/darwin-x64": "0.11.0",
+    "@badness/darwin-arm64": "0.11.0",
+    "@badness/win32-x64": "0.11.0",
+    "@badness/win32-arm64": "0.11.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.11.0](https://github.com/jolars/badness/compare/v0.10.0...v0.11.0) (2026-07-20)

### Breaking changes
- **lsp:** move texmf config to editor settings ([`2f83a84`](https://github.com/jolars/badness/commit/2f83a844a6876906e69843053cafb59ed6e5232b))

### Features
- **lsp:** move texmf config to editor settings ([`2f83a84`](https://github.com/jolars/badness/commit/2f83a844a6876906e69843053cafb59ed6e5232b))
- **formatter:** hang nested blocks in align grids ([`5103bab`](https://github.com/jolars/badness/commit/5103babda2aa884f8dc5abe1b55a7fd2d3402fa5))
- **linter:** document bib rules in --explain and docs ([`a2a742c`](https://github.com/jolars/badness/commit/a2a742ccd9db648ae60d90359a8118364fdd60b7)), closes [#24](https://github.com/jolars/badness/issues/24)

### Bug Fixes
- **tests:** adapt to `lsp-server` 0.10 `Response` API ([`5f1e889`](https://github.com/jolars/badness/commit/5f1e889969c92a4d2f58fc3d4fb6365ed6b696d2))
- **linter:** skip script labels inside argument groups ([`1f8c0eb`](https://github.com/jolars/badness/commit/1f8c0ebed5e3ae93d617dc23195288446720ae46)), closes [#37](https://github.com/jolars/badness/issues/37)
- **parser:** name blank line as math terminator ([`2751787`](https://github.com/jolars/badness/commit/2751787acad3f69588eb66dfc562bb293e743a7f)), ref [#35](https://github.com/jolars/badness/issues/35)
- **linter:** ignore key arguments in dash-length ([`506e5f0`](https://github.com/jolars/badness/commit/506e5f0a365d1f5d988cdcd99706edab7ed435a8))
- **linter:** ignore rule-command spans in dash-length ([`adeecf6`](https://github.com/jolars/badness/commit/adeecf69d79cfb38d52f4187184104385feaad71)), closes [#34](https://github.com/jolars/badness/issues/34)
- **linter:** ignore key arguments in math-shape rules ([`387810a`](https://github.com/jolars/badness/commit/387810a7fbca8a9fd298634659c06dbb18ac0b6e)), closes [#25](https://github.com/jolars/badness/issues/25)
- **parser:** keep unmatched `[` a plain atom in math ([`c185c13`](https://github.com/jolars/badness/commit/c185c1338aa830646db53c344dd2638240ebbb0f)), closes [#23](https://github.com/jolars/badness/issues/23)
- **linter:** ignore labels in exclusive conditional branches ([`a6e0c22`](https://github.com/jolars/badness/commit/a6e0c228c177d25bd071a3ea8062ad8c9484c0aa))
- **linter:** ignore package loads in exclusive branches ([`d16d3d1`](https://github.com/jolars/badness/commit/d16d3d1a71c3abe6bca1fb78ee46e18d3b8aff33)), closes [#27](https://github.com/jolars/badness/issues/27)
- **linter:** target the whole construct for DOC_COMMENT-bound suppressions ([`cd647fa`](https://github.com/jolars/badness/commit/cd647fae218e61335ca080bda065d2c2b3425387)), fixes [#26](https://github.com/jolars/badness/issues/26)

## [editors/code: 0.11.0](https://github.com/jolars/badness/compare/badness-code-v0.10.0...badness-code-v0.11.0) (2026-07-20)

### Dependencies
- updated badness to v0.11.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).