### PR TITLE
feat: add stable-diff paragraph wrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,8 @@ are implemented.
 
 **Configuration (`badness.toml`).** Discovered by an ancestor walk from each input
 (`config.rs`); the **CLI is the only consumer**—the library API takes a fully-resolved
-`FormatStyle`. Sections include `[format]` (`line-width`, `wrap-target`, `indent-width`,
-`wrap`, `math-wrap`, `lang`, `no-break-abbreviations`), and `[build]` (`aux-dir`). Excludes
-follow
+`FormatStyle`. Sections include `[format]` (`line-width`, `indent-width`, `wrap`,
+`math-wrap`, `lang`, `no-break-abbreviations`) and `[build]` (`aux-dir`). Excludes follow
 the Ruff model (`exclude` *replaces* the built-in `DEFAULT_EXCLUDE`; `extend-exclude` is
 additive). `wrap` is optional and resolves per file kind when omitted. This keeps the
 formatter hermetic (config is local project data, not the environment). TEXMF discovery
@@ -428,14 +427,15 @@ never match.
   carries `Align`, `IfBreak`, `ConditionalGroup`(`AllLines`), `Verbatim`, `ColumnZero`,
   `MarginPrefix`, and `Nil`—see `ir.rs` for the authoritative list.
 - **Paragraph line breaks** are controlled by a `WrapMode` (`Reflow` default,
-  `Minimal`, `Sentence`, `Semantic`/sembr, `Preserve`), modeled on the sibling
+  `Stable`, `Sentence`, `Semantic`/sembr, `Preserve`), modeled on the sibling
   **panache** formatter and mechanized through the `Doc` IR, not a separate line-filler.
-  All five are implemented: `Reflow` width-fills, `Minimal` keeps acceptable authored
-  breaks while optimizing overflow/underflow/change/displacement/raggedness against
-  `[format] wrap-target` (default `line-width - 10`), `Preserve` keeps authored breaks,
+  All five are implemented: `Reflow` width-fills, `Stable` keeps acceptable authored
+  breaks while optimizing overflow/underflow/change/displacement/raggedness against a
+  hard-coded soft target (`FormatStyle::stable_wrap_target`, `line-width - 15`; not yet
+  configurable), `Preserve` keeps authored breaks,
   and `Sentence`/`Semantic` split one sentence per line (width ignored) through the
   shared `reflow_elements` engine—each completed prose run is rendered as a `Fill`
-  (reflow), a `PreferredFill` (minimal), or as space-joined sentences
+  (reflow), a `PreferredFill` (stable), or as space-joined sentences
   (sentence/semantic). `Semantic` additionally
   ends a line at every authored newline (sembr; no clause detection). Sentence-boundary
   detection is a per-language abbreviation profile (`formatter::sentence`, ported from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ are implemented.
 
 **Configuration (`badness.toml`).** Discovered by an ancestor walk from each input
 (`config.rs`); the **CLI is the only consumer**—the library API takes a fully-resolved
-`FormatStyle`. Sections include `[format]` (`line-width`, `indent-width`, `wrap`,
-`math-wrap`, `lang`, `no-break-abbreviations`), and `[build]` (`aux-dir`). Excludes follow
+`FormatStyle`. Sections include `[format]` (`line-width`, `wrap-target`, `indent-width`,
+`wrap`, `math-wrap`, `lang`, `no-break-abbreviations`), and `[build]` (`aux-dir`). Excludes
+follow
 the Ruff model (`exclude` *replaces* the built-in `DEFAULT_EXCLUDE`; `extend-exclude` is
 additive). `wrap` is optional and resolves per file kind when omitted. This keeps the
 formatter hermetic (config is local project data, not the environment). TEXMF discovery
@@ -421,17 +422,21 @@ never match.
   and fights tower-lsp's async `&self` model. `text/line_index.rs` uses
   `lsp_types::Position`.
 - **Formatter engine:** a Wadler/Prettier-style `Doc` IR (`formatter::ir::Ir`), whose
-  core variants are `Group`/`Line`/`SoftLine`/`HardLine`/`EmptyLine`/`Indent` plus an
-  `Ir::Fill` node (per-gap greedy break decisions) for paragraph reflow. The enum also
+  core variants are `Group`/`Line`/`SoftLine`/`HardLine`/`EmptyLine`/`Indent` plus
+  `Ir::Fill` (per-gap greedy break decisions) and `Ir::PreferredFill`
+  (source-break-aware global minimum-cost decisions) for paragraph reflow. The enum also
   carries `Align`, `IfBreak`, `ConditionalGroup`(`AllLines`), `Verbatim`, `ColumnZero`,
   `MarginPrefix`, and `Nil`—see `ir.rs` for the authoritative list.
 - **Paragraph line breaks** are controlled by a `WrapMode` (`Reflow` default,
-  `Sentence`, `Semantic`/sembr, `Preserve`), modeled on the sibling **panache**
-  formatter and mechanized through the `Doc` IR (`Fill`), not a separate line-filler.
-  All four are implemented: `Reflow` width-fills, `Preserve` keeps authored breaks,
+  `Minimal`, `Sentence`, `Semantic`/sembr, `Preserve`), modeled on the sibling
+  **panache** formatter and mechanized through the `Doc` IR, not a separate line-filler.
+  All five are implemented: `Reflow` width-fills, `Minimal` keeps acceptable authored
+  breaks while optimizing overflow/underflow/change/displacement/raggedness against
+  `[format] wrap-target` (default `line-width - 10`), `Preserve` keeps authored breaks,
   and `Sentence`/`Semantic` split one sentence per line (width ignored) through the
   shared `reflow_elements` engine—each completed prose run is rendered as a `Fill`
-  (reflow) or as space-joined sentences (sentence/semantic). `Semantic` additionally
+  (reflow), a `PreferredFill` (minimal), or as space-joined sentences
+  (sentence/semantic). `Semantic` additionally
   ends a line at every authored newline (sembr; no clause detection). Sentence-boundary
   detection is a per-language abbreviation profile (`formatter::sentence`, ported from
   panache) resolved from `[format] lang` + `[format.no-break-abbreviations]` into a

--- a/TODO.md
+++ b/TODO.md
@@ -296,7 +296,7 @@ completion items (VS Code-only), and sub/superscript history completion
   (`GlobalState::resolve_settings`, cached by anchor dir, cleared on
   `didChangeConfiguration`). A discovered config wins outright
   (file-wins); editor settings are the fallback. Both `[format]` (`line-width`,
-  `wrap-target`, `indent-width`, `wrap`) and `[lint]` (`select`/`ignore`, applied via
+  `indent-width`, `wrap`) and `[lint]` (`select`/`ignore`, applied via
   `RuleSelection` in the analyze/diagnostic/code-action paths) are honored. Two
   follow-ups remain:
   - Deliberately *not* done: plumbing `wrap` (or other knobs) through
@@ -310,10 +310,13 @@ completion items (VS Code-only), and sub/superscript history completion
 
 ### Formatting
 
-- [x] Minimal-diff paragraph wrapping: `wrap = "minimal"` retains authored
-  equilibrium breaks and uses `wrap-target` as a soft target under the hard
-  `line-width`; implemented as source-aware `PreferredFill` IR with global
-  lexicographic layout selection, preserving the formatter-engine boundary.
+- [x] Revision-stable paragraph wrapping: `wrap = "stable"` retains authored
+  equilibrium breaks and uses a hard-coded soft target (`line-width - 15`, see
+  `FormatStyle::stable_wrap_target`) under the hard `line-width`; implemented as
+  source-aware `PreferredFill` IR with global lexicographic layout selection,
+  preserving the formatter-engine boundary. Follow-up: expose the soft target as a
+  config knob only if a concrete need appears; reserve `wrap = "minimal"` for a
+  truly minimal mode that only reflows over-long lines.
 
 ### Navigation & structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -296,7 +296,7 @@ completion items (VS Code-only), and sub/superscript history completion
   (`GlobalState::resolve_settings`, cached by anchor dir, cleared on
   `didChangeConfiguration`). A discovered config wins outright
   (file-wins); editor settings are the fallback. Both `[format]` (`line-width`,
-  `indent-width`, `wrap`) and `[lint]` (`select`/`ignore`, applied via
+  `wrap-target`, `indent-width`, `wrap`) and `[lint]` (`select`/`ignore`, applied via
   `RuleSelection` in the analyze/diagnostic/code-action paths) are honored. Two
   follow-ups remain:
   - Deliberately *not* done: plumbing `wrap` (or other knobs) through
@@ -309,6 +309,11 @@ completion items (VS Code-only), and sub/superscript history completion
   drive interactive diagnostics through `textDocument/diagnostic` meanwhile.
 
 ### Formatting
+
+- [x] Minimal-diff paragraph wrapping: `wrap = "minimal"` retains authored
+  equilibrium breaks and uses `wrap-target` as a soft target under the hard
+  `line-width`; implemented as source-aware `PreferredFill` IR with global
+  lexicographic layout selection, preserving the formatter-engine boundary.
 
 ### Navigation & structure
 

--- a/docs/src/guide/formatting.md
+++ b/docs/src/guide/formatting.md
@@ -14,9 +14,9 @@ badness format --check paper.tex  # report, don't write; non-zero if unformatted
 
 ## Style Options
 
-The style flags---`--line-width`, `--wrap-target`, `--indent-width`, and
-`--wrap`---mirror the `[format]` section of `badness.toml` and override it for a
-single run. Each option's default and meaning is listed in the [Configuration
+The style flags---`--line-width`, `--indent-width`, and `--wrap`---mirror the
+`[format]` section of `badness.toml` and override it for a single run. Each
+option's default and meaning is listed in the [Configuration
 reference](../reference/configuration.md#format).
 
 For persistent settings, badness reads a `badness.toml` discovered from the

--- a/docs/src/guide/formatting.md
+++ b/docs/src/guide/formatting.md
@@ -14,9 +14,9 @@ badness format --check paper.tex  # report, don't write; non-zero if unformatted
 
 ## Style Options
 
-The style flags---`--line-width`, `--indent-width`, and `--wrap`---mirror the
-`[format]` section of `badness.toml` and override it for a single run. Each
-option's default and meaning is listed in the [Configuration
+The style flags---`--line-width`, `--wrap-target`, `--indent-width`, and
+`--wrap`---mirror the `[format]` section of `badness.toml` and override it for a
+single run. Each option's default and meaning is listed in the [Configuration
 reference](../reference/configuration.md#format).
 
 For persistent settings, badness reads a `badness.toml` discovered from the

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -36,9 +36,6 @@ With paths, formats each file in place. With no paths, reads stdin and writes th
 `--line-width <LINE_WIDTH>`
 :   Maximum line width before the formatter breaks a line
 
-`--wrap-target <WRAP_TARGET>`
-:   Soft line-length target used by `--wrap minimal`
-
 `--indent-width <INDENT_WIDTH>`
 :   Number of spaces per indent step
 
@@ -48,7 +45,7 @@ With paths, formats each file in place. With no paths, reads stdin and writes th
     Possible values:
 
     - `reflow`: Greedy fill: wrap words to the line width (default)
-    - `minimal`: Preserve acceptable authored breaks and rebalance only nearby text
+    - `stable`: Preserve acceptable authored breaks and rebalance only nearby text (revision-stable wrapping)
     - `sentence`: One sentence per line (line width ignored)
     - `semantic`: Semantic line breaks (sembr.org): keep authored breaks and add breaks at sentence boundaries
     - `preserve`: Leave authored line breaks untouched

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -36,6 +36,9 @@ With paths, formats each file in place. With no paths, reads stdin and writes th
 `--line-width <LINE_WIDTH>`
 :   Maximum line width before the formatter breaks a line
 
+`--wrap-target <WRAP_TARGET>`
+:   Soft line-length target used by `--wrap minimal`
+
 `--indent-width <INDENT_WIDTH>`
 :   Number of spaces per indent step
 
@@ -45,6 +48,7 @@ With paths, formats each file in place. With no paths, reads stdin and writes th
     Possible values:
 
     - `reflow`: Greedy fill: wrap words to the line width (default)
+    - `minimal`: Preserve acceptable authored breaks and rebalance only nearby text
     - `sentence`: One sentence per line (line width ignored)
     - `semantic`: Semantic line breaks (sembr.org): keep authored breaks and add breaks at sentence boundaries
     - `preserve`: Leave authored line breaks untouched

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -12,8 +12,9 @@ its default.
 
 [format]
 # line-width = 80
+# wrap-target = 70  # soft target used only by wrap = "minimal"
 # indent-width = 2
-# wrap = "reflow"  # reflow | sentence | semantic | preserve
+# wrap = "reflow"  # reflow | minimal | sentence | semantic | preserve
 
 [lint]
 # select = ["..."]  # if set, only these rules run
@@ -119,6 +120,26 @@ Maximum line width before the formatter breaks a line. Must be between 1 and 100
 line-width = 100
 ```
 
+### `wrap-target`
+
+Soft line-length target used by [`wrap = "minimal"`](#wrap). The hard maximum
+remains [`line-width`](#line-width); this target determines when an authored
+line break is already close enough to equilibrium to preserve. When omitted,
+it defaults to ten columns below `line-width`, floored at one column. It must be
+between 1 and `line-width`.
+
+**Default value**: `line-width - 10` (at least `1`)
+
+**Type**: integer
+
+**Example**:
+
+```toml
+[format]
+line-width = 100
+wrap-target = 85
+```
+
 ### `indent-width`
 
 Spaces per indent step. Must be between 1 and 1000.
@@ -142,6 +163,7 @@ structure—only where soft line breaks fall.
   | Mode       | Behavior                                                                                                        |
   | ---------- | --------------------------------------------------------------------------------------------------------------- |
   | `reflow`   | Greedy fill: pack words up to `line-width`, breaking only where the next word would overflow.                   |
+  | `minimal`  | Preserve acceptable authored breaks and rebalance only text that no longer fits.                               |
   | `preserve` | Leave the authored line breaks untouched.                                                                       |
   | `sentence` | One sentence per line. Line width is ignored—a long sentence stays on one line.                                 |
   | `semantic` | [Semantic line breaks](https://sembr.org): keep the author's soft breaks *and* add a break after each sentence. |
@@ -161,6 +183,16 @@ clause boundaries itself—a break after a comma or `and` survives only where th
 author placed a newline. A run-on sentence on a single source line is still
 sentence-split.
 
+`minimal` also preserves authored line breaks, but treats them as preferred
+anchors rather than hard boundaries. Each prose run is solved as one global
+layout problem. Candidate layouts are compared lexicographically by total
+overflow, underflow below `wrap-target`, changed authored breaks, displacement
+from the nearest authored break, raggedness around `wrap-target`, and line
+count. This makes the hard width non-negotiable before minimizing source churn,
+while a short final line remains unpenalized. Blank lines and command-only lines
+bound each independently optimized run, and code-like statement bodies retain
+ordinary greedy fill.
+
 When omitted, the formatter uses each file kind's default: `.tex` and `.bib`
 files reflow, while code-heavy `.sty`, `.cls`, `.dtx`, and `.ins` files preserve
 authored line breaks. Setting `wrap` applies the same mode to every file kind.
@@ -168,13 +200,14 @@ authored line breaks. Setting `wrap` applies the same mode to every file kind.
 **Default value**: unset (per file kind: `.tex`/`.bib` → `reflow`,
 `.sty`/`.cls`/`.dtx`/`.ins` → `preserve`)
 
-**Type**: `"reflow" | "sentence" | "semantic" | "preserve"`
+**Type**: `"reflow" | "minimal" | "sentence" | "semantic" | "preserve"`
 
 **Example**:
 
 ```toml
 [format]
-wrap = "sentence"
+wrap = "minimal"
+wrap-target = 70
 ```
 
 ### `math-wrap`

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -12,9 +12,8 @@ its default.
 
 [format]
 # line-width = 80
-# wrap-target = 70  # soft target used only by wrap = "minimal"
 # indent-width = 2
-# wrap = "reflow"  # reflow | minimal | sentence | semantic | preserve
+# wrap = "reflow"  # reflow | stable | sentence | semantic | preserve
 
 [lint]
 # select = ["..."]  # if set, only these rules run
@@ -120,26 +119,6 @@ Maximum line width before the formatter breaks a line. Must be between 1 and 100
 line-width = 100
 ```
 
-### `wrap-target`
-
-Soft line-length target used by [`wrap = "minimal"`](#wrap). The hard maximum
-remains [`line-width`](#line-width); this target determines when an authored
-line break is already close enough to equilibrium to preserve. When omitted,
-it defaults to ten columns below `line-width`, floored at one column. It must be
-between 1 and `line-width`.
-
-**Default value**: `line-width - 10` (at least `1`)
-
-**Type**: integer
-
-**Example**:
-
-```toml
-[format]
-line-width = 100
-wrap-target = 85
-```
-
 ### `indent-width`
 
 Spaces per indent step. Must be between 1 and 1000.
@@ -163,7 +142,7 @@ structure—only where soft line breaks fall.
   | Mode       | Behavior                                                                                                        |
   | ---------- | --------------------------------------------------------------------------------------------------------------- |
   | `reflow`   | Greedy fill: pack words up to `line-width`, breaking only where the next word would overflow.                   |
-  | `minimal`  | Preserve acceptable authored breaks and rebalance only text that no longer fits.                               |
+  | `stable`   | Preserve acceptable authored breaks and rebalance only text that no longer fits (keeps revision diffs small).   |
   | `preserve` | Leave the authored line breaks untouched.                                                                       |
   | `sentence` | One sentence per line. Line width is ignored—a long sentence stays on one line.                                 |
   | `semantic` | [Semantic line breaks](https://sembr.org): keep the author's soft breaks *and* add a break after each sentence. |
@@ -183,15 +162,17 @@ clause boundaries itself—a break after a comma or `and` survives only where th
 author placed a newline. A run-on sentence on a single source line is still
 sentence-split.
 
-`minimal` also preserves authored line breaks, but treats them as preferred
-anchors rather than hard boundaries. Each prose run is solved as one global
-layout problem. Candidate layouts are compared lexicographically by total
-overflow, underflow below `wrap-target`, changed authored breaks, displacement
-from the nearest authored break, raggedness around `wrap-target`, and line
-count. This makes the hard width non-negotiable before minimizing source churn,
-while a short final line remains unpenalized. Blank lines and command-only lines
-bound each independently optimized run, and code-like statement bodies retain
-ordinary greedy fill.
+`stable` also preserves authored line breaks, but treats them as preferred
+anchors rather than hard boundaries. It is aimed at keeping revision diffs
+small: a small prose edit perturbs the smallest possible region. Each prose run
+is solved as one global layout problem. Candidate layouts are compared
+lexicographically by total overflow, underflow below a soft target
+(`line-width - 15`), changed authored breaks, displacement from the nearest
+authored break, raggedness around that target, and line count. This makes the
+hard width non-negotiable before minimizing source churn, while a short final
+line remains unpenalized. Blank lines and command-only lines bound each
+independently optimized run, and code-like statement bodies retain ordinary
+greedy fill. (The soft target is not currently configurable.)
 
 When omitted, the formatter uses each file kind's default: `.tex` and `.bib`
 files reflow, while code-heavy `.sty`, `.cls`, `.dtx`, and `.ins` files preserve
@@ -200,14 +181,13 @@ authored line breaks. Setting `wrap` applies the same mode to every file kind.
 **Default value**: unset (per file kind: `.tex`/`.bib` → `reflow`,
 `.sty`/`.cls`/`.dtx`/`.ins` → `preserve`)
 
-**Type**: `"reflow" | "minimal" | "sentence" | "semantic" | "preserve"`
+**Type**: `"reflow" | "stable" | "sentence" | "semantic" | "preserve"`
 
 **Example**:
 
 ```toml
 [format]
-wrap = "minimal"
-wrap-target = 70
+wrap = "stable"
 ```
 
 ### `math-wrap`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,8 +16,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 pub enum WrapArg {
     /// Greedy fill: wrap words to the line width (default).
     Reflow,
-    /// Preserve acceptable authored breaks and rebalance only nearby text.
-    Minimal,
+    /// Preserve acceptable authored breaks and rebalance only nearby text
+    /// (revision-stable wrapping).
+    Stable,
     /// One sentence per line (line width ignored).
     Sentence,
     /// Semantic line breaks (sembr.org): keep authored breaks and add breaks at
@@ -82,9 +83,6 @@ pub enum Command {
         /// Maximum line width before the formatter breaks a line.
         #[arg(long)]
         line_width: Option<usize>,
-        /// Soft line-length target used by `--wrap minimal`.
-        #[arg(long)]
-        wrap_target: Option<usize>,
         /// Number of spaces per indent step.
         #[arg(long)]
         indent_width: Option<usize>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 pub enum WrapArg {
     /// Greedy fill: wrap words to the line width (default).
     Reflow,
+    /// Preserve acceptable authored breaks and rebalance only nearby text.
+    Minimal,
     /// One sentence per line (line width ignored).
     Sentence,
     /// Semantic line breaks (sembr.org): keep authored breaks and add breaks at
@@ -80,6 +82,9 @@ pub enum Command {
         /// Maximum line width before the formatter breaks a line.
         #[arg(long)]
         line_width: Option<usize>,
+        /// Soft line-length target used by `--wrap minimal`.
+        #[arg(long)]
+        wrap_target: Option<usize>,
         /// Number of spaces per indent step.
         #[arg(long)]
         indent_width: Option<usize>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,10 @@ pub struct FormatConfig {
     pub line_width: u32,
     #[serde(default = "default_indent_width")]
     pub indent_width: u32,
+    /// Soft line-length target for `wrap = "minimal"`. When omitted, minimal
+    /// wrapping targets ten columns below `line-width`.
+    #[serde(default)]
+    pub wrap_target: Option<u32>,
     /// The paragraph line-break policy. See [`WrapModeConfig`]. When omitted, the
     /// formatter uses each file kind's default
     /// ([`FileKind::default_wrap`](crate::file_discovery::FileKind::default_wrap)):
@@ -130,6 +134,7 @@ impl Default for FormatConfig {
         Self {
             line_width: DEFAULT_LINE_WIDTH,
             indent_width: DEFAULT_INDENT_WIDTH,
+            wrap_target: None,
             wrap: None,
             math_wrap: None,
             lang: None,
@@ -147,6 +152,8 @@ impl Default for FormatConfig {
 pub enum WrapModeConfig {
     /// Greedy fill: wrap words to the line width.
     Reflow,
+    /// Prefer acceptable authored breaks, changing the smallest possible region.
+    Minimal,
     /// One sentence per line (width ignored).
     Sentence,
     /// Semantic line breaks (sembr.org): keep authored breaks and add breaks at
@@ -160,6 +167,7 @@ impl From<WrapModeConfig> for WrapMode {
     fn from(value: WrapModeConfig) -> Self {
         match value {
             WrapModeConfig::Reflow => WrapMode::Reflow,
+            WrapModeConfig::Minimal => WrapMode::Minimal,
             WrapModeConfig::Sentence => WrapMode::Sentence,
             WrapModeConfig::Semantic => WrapMode::Semantic,
             WrapModeConfig::Preserve => WrapMode::Preserve,
@@ -202,6 +210,19 @@ impl FormatConfig {
     pub fn validate(&self, path: Option<&Path>) -> Result<(), ConfigError> {
         validate_width("line-width", self.line_width, path)?;
         validate_width("indent-width", self.indent_width, path)?;
+        if let Some(target) = self.wrap_target {
+            validate_width("wrap-target", target, path)?;
+            if target > self.line_width {
+                return Err(ConfigError::InvalidValue {
+                    path: path.map(Path::to_path_buf),
+                    field: "wrap-target",
+                    message: format!(
+                        "must not exceed line-width ({}), got {target}",
+                        self.line_width
+                    ),
+                });
+            }
+        }
         Ok(())
     }
 }
@@ -256,6 +277,7 @@ impl From<&FormatConfig> for FormatStyle {
             // configured value (or `Auto`) maps straight through, and `Auto`
             // resolves against the effective wrap inside the formatter.
             math_wrap: config.math_wrap.map_or(MathWrap::Auto, Into::into),
+            wrap_target: config.wrap_target.map(|width| width as usize),
         }
     }
 }
@@ -599,6 +621,7 @@ mod tests {
     fn parses_wrap_variants() {
         for (key, expected) in [
             ("reflow", WrapModeConfig::Reflow),
+            ("minimal", WrapModeConfig::Minimal),
             ("sentence", WrapModeConfig::Sentence),
             ("semantic", WrapModeConfig::Semantic),
             ("preserve", WrapModeConfig::Preserve),
@@ -613,6 +636,7 @@ mod tests {
     fn expected_wrap_mode(key: &str) -> WrapMode {
         match key {
             "reflow" => WrapMode::Reflow,
+            "minimal" => WrapMode::Minimal,
             "sentence" => WrapMode::Sentence,
             "semantic" => WrapMode::Semantic,
             "preserve" => WrapMode::Preserve,
@@ -652,6 +676,36 @@ mod tests {
     fn rejects_unknown_math_wrap() {
         let err = parse("[format]\nmath-wrap = \"never\"\n").expect_err("unknown variant");
         assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn parses_wrap_target() {
+        let config = parse("[format]\nline-width = 100\nwrap = \"minimal\"\nwrap-target = 85\n")
+            .expect("parse");
+        let style = FormatStyle::from(&config.format);
+        assert_eq!(config.format.wrap, Some(WrapModeConfig::Minimal));
+        assert_eq!(style.wrap_target, Some(85));
+    }
+
+    #[test]
+    fn minimal_wrap_target_defaults_below_line_width() {
+        let config = parse("[format]\nline-width = 100\nwrap = \"minimal\"\n").expect("parse");
+        let style = FormatStyle::from(&config.format);
+        assert_eq!(style.wrap_target, None);
+        assert_eq!(style.effective_wrap_target(), 90);
+    }
+
+    #[test]
+    fn rejects_wrap_target_above_line_width() {
+        let err = parse("[format]\nline-width = 80\nwrap-target = 81\n")
+            .expect_err("target above hard width");
+        assert!(matches!(
+            err,
+            ConfigError::InvalidValue {
+                field: "wrap-target",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,10 +99,6 @@ pub struct FormatConfig {
     pub line_width: u32,
     #[serde(default = "default_indent_width")]
     pub indent_width: u32,
-    /// Soft line-length target for `wrap = "minimal"`. When omitted, minimal
-    /// wrapping targets ten columns below `line-width`.
-    #[serde(default)]
-    pub wrap_target: Option<u32>,
     /// The paragraph line-break policy. See [`WrapModeConfig`]. When omitted, the
     /// formatter uses each file kind's default
     /// ([`FileKind::default_wrap`](crate::file_discovery::FileKind::default_wrap)):
@@ -134,7 +130,6 @@ impl Default for FormatConfig {
         Self {
             line_width: DEFAULT_LINE_WIDTH,
             indent_width: DEFAULT_INDENT_WIDTH,
-            wrap_target: None,
             wrap: None,
             math_wrap: None,
             lang: None,
@@ -152,8 +147,9 @@ impl Default for FormatConfig {
 pub enum WrapModeConfig {
     /// Greedy fill: wrap words to the line width.
     Reflow,
-    /// Prefer acceptable authored breaks, changing the smallest possible region.
-    Minimal,
+    /// Prefer acceptable authored breaks, changing the smallest possible region
+    /// (revision-stable wrapping).
+    Stable,
     /// One sentence per line (width ignored).
     Sentence,
     /// Semantic line breaks (sembr.org): keep authored breaks and add breaks at
@@ -167,7 +163,7 @@ impl From<WrapModeConfig> for WrapMode {
     fn from(value: WrapModeConfig) -> Self {
         match value {
             WrapModeConfig::Reflow => WrapMode::Reflow,
-            WrapModeConfig::Minimal => WrapMode::Minimal,
+            WrapModeConfig::Stable => WrapMode::Stable,
             WrapModeConfig::Sentence => WrapMode::Sentence,
             WrapModeConfig::Semantic => WrapMode::Semantic,
             WrapModeConfig::Preserve => WrapMode::Preserve,
@@ -210,19 +206,6 @@ impl FormatConfig {
     pub fn validate(&self, path: Option<&Path>) -> Result<(), ConfigError> {
         validate_width("line-width", self.line_width, path)?;
         validate_width("indent-width", self.indent_width, path)?;
-        if let Some(target) = self.wrap_target {
-            validate_width("wrap-target", target, path)?;
-            if target > self.line_width {
-                return Err(ConfigError::InvalidValue {
-                    path: path.map(Path::to_path_buf),
-                    field: "wrap-target",
-                    message: format!(
-                        "must not exceed line-width ({}), got {target}",
-                        self.line_width
-                    ),
-                });
-            }
-        }
         Ok(())
     }
 }
@@ -277,7 +260,6 @@ impl From<&FormatConfig> for FormatStyle {
             // configured value (or `Auto`) maps straight through, and `Auto`
             // resolves against the effective wrap inside the formatter.
             math_wrap: config.math_wrap.map_or(MathWrap::Auto, Into::into),
-            wrap_target: config.wrap_target.map(|width| width as usize),
         }
     }
 }
@@ -621,7 +603,7 @@ mod tests {
     fn parses_wrap_variants() {
         for (key, expected) in [
             ("reflow", WrapModeConfig::Reflow),
-            ("minimal", WrapModeConfig::Minimal),
+            ("stable", WrapModeConfig::Stable),
             ("sentence", WrapModeConfig::Sentence),
             ("semantic", WrapModeConfig::Semantic),
             ("preserve", WrapModeConfig::Preserve),
@@ -636,7 +618,7 @@ mod tests {
     fn expected_wrap_mode(key: &str) -> WrapMode {
         match key {
             "reflow" => WrapMode::Reflow,
-            "minimal" => WrapMode::Minimal,
+            "stable" => WrapMode::Stable,
             "sentence" => WrapMode::Sentence,
             "semantic" => WrapMode::Semantic,
             "preserve" => WrapMode::Preserve,
@@ -679,33 +661,11 @@ mod tests {
     }
 
     #[test]
-    fn parses_wrap_target() {
-        let config = parse("[format]\nline-width = 100\nwrap = \"minimal\"\nwrap-target = 85\n")
-            .expect("parse");
+    fn stable_wrap_target_sits_below_line_width() {
+        let config = parse("[format]\nline-width = 100\nwrap = \"stable\"\n").expect("parse");
         let style = FormatStyle::from(&config.format);
-        assert_eq!(config.format.wrap, Some(WrapModeConfig::Minimal));
-        assert_eq!(style.wrap_target, Some(85));
-    }
-
-    #[test]
-    fn minimal_wrap_target_defaults_below_line_width() {
-        let config = parse("[format]\nline-width = 100\nwrap = \"minimal\"\n").expect("parse");
-        let style = FormatStyle::from(&config.format);
-        assert_eq!(style.wrap_target, None);
-        assert_eq!(style.effective_wrap_target(), 90);
-    }
-
-    #[test]
-    fn rejects_wrap_target_above_line_width() {
-        let err = parse("[format]\nline-width = 80\nwrap-target = 81\n")
-            .expect_err("target above hard width");
-        assert!(matches!(
-            err,
-            ConfigError::InvalidValue {
-                field: "wrap-target",
-                ..
-            }
-        ));
+        assert_eq!(config.format.wrap, Some(WrapModeConfig::Stable));
+        assert_eq!(style.stable_wrap_target(), 85);
     }
 
     #[test]

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -343,7 +343,7 @@ fn format_root(
         // Resolved here (never `Auto` past this point), so per-file-kind wrap
         // defaults and library callers get the derivation for free.
         math_wrap: ctx.style().math_wrap.resolve(ctx.style().wrap),
-        wrap_target: ctx.style().effective_wrap_target(),
+        stable_target: ctx.style().stable_wrap_target(),
         signatures: Signatures::new(&user),
         expl3_regions: &regions,
         profile,
@@ -546,9 +546,9 @@ struct LowerCtx<'a> {
     /// Display-math break policy, pre-resolved against `wrap` in
     /// [`format_root`] — never [`MathWrap::Auto`] here.
     math_wrap: MathWrap,
-    /// Effective soft line target for [`WrapMode::Minimal`]. Already defaulted
-    /// and clamped against the hard width by [`FormatStyle`].
-    wrap_target: usize,
+    /// Soft equilibrium line target for [`WrapMode::Stable`]. Already derived and
+    /// clamped against the hard width by [`FormatStyle::stable_wrap_target`].
+    stable_target: usize,
     signatures: Signatures<'a>,
     /// Sorted, non-overlapping byte ranges of the document's expl3 regions (see
     /// [`expl3_regions`]). Inside these, source whitespace is catcode-9 (ignored)
@@ -559,8 +559,8 @@ struct LowerCtx<'a> {
     /// The sentence-boundary profile (built-in language plus user no-break
     /// abbreviations) for the [`WrapMode::Sentence`]/[`WrapMode::Semantic`] modes.
     /// `Copy`, borrowing the merged slice owned by [`format_root`]. Never consulted
-    /// under [`WrapMode::Reflow`]/[`WrapMode::Minimal`]/[`WrapMode::Preserve`], so an English default
-    /// (see [`SentenceOptions::default`]) is harmless there.
+    /// under [`WrapMode::Reflow`]/[`WrapMode::Stable`]/[`WrapMode::Preserve`], so an
+    /// English default (see [`SentenceOptions::default`]) is harmless there.
     profile: ResolvedProfile<'a>,
     /// Range-formatting emission filter. When `Some`, only the [`SyntaxKind::ROOT`]
     /// children overlapping this byte range are lowered (the in-range top-level
@@ -579,7 +579,7 @@ impl<'a> LowerCtx<'a> {
     fn wraps_prose(self) -> bool {
         matches!(
             self.wrap,
-            WrapMode::Reflow | WrapMode::Minimal | WrapMode::Sentence | WrapMode::Semantic
+            WrapMode::Reflow | WrapMode::Stable | WrapMode::Sentence | WrapMode::Semantic
         )
     }
 
@@ -938,7 +938,7 @@ const DTX_DOC_MARGIN: &str = "% ";
 /// One committed atom of a logical-line run: the printed [`Ir`] plus the atom's
 /// source `text`, retained so the [`WrapMode::Sentence`]/[`WrapMode::Semantic`]
 /// renderer can run sentence-boundary detection over the words. Under
-/// [`WrapMode::Reflow`]/[`WrapMode::Minimal`] only the layout fields are used.
+/// [`WrapMode::Reflow`]/[`WrapMode::Stable`] only the layout fields are used.
 struct RunAtom {
     ir: Ir,
     text: String,
@@ -953,8 +953,8 @@ enum RunRender<'a> {
     /// Greedy width fill (reflow): one [`Ir::fill`] over the run's atoms, the
     /// printer breaking word-by-word at the line width.
     Fill,
-    /// Source-break-aware optimal fill used by [`WrapMode::Minimal`].
-    Minimal { target: usize },
+    /// Source-break-aware optimal fill used by [`WrapMode::Stable`].
+    Stable { target: usize },
     /// One sentence per line (sentence/semantic): cut the run at sentence
     /// boundaries and lay each sentence flat (space-joined), separating sentences
     /// with a hard break. Width is ignored — a long sentence stays on one line.
@@ -1121,7 +1121,7 @@ impl<'a> LineBuilder<'a> {
         let run = std::mem::take(&mut self.run);
         let body = match self.render {
             RunRender::Fill => Ir::fill(run.into_iter().map(|a| a.ir)),
-            RunRender::Minimal { target } => {
+            RunRender::Stable { target } => {
                 let preferred: Vec<bool> = run
                     .iter()
                     .skip(1)
@@ -1170,8 +1170,8 @@ fn reflow_elements(
     // Sentence/semantic segmentation applies to *prose* runs; a `Statement` run is
     // code (a `\newcommand` body), so it keeps the width fill regardless of mode.
     let render = match cx.wrap {
-        WrapMode::Minimal if kind != ReflowKind::Statement => RunRender::Minimal {
-            target: cx.wrap_target,
+        WrapMode::Stable if kind != ReflowKind::Statement => RunRender::Stable {
+            target: cx.stable_target,
         },
         WrapMode::Sentence | WrapMode::Semantic if kind != ReflowKind::Statement => {
             RunRender::Sentence(cx.profile)
@@ -1231,7 +1231,7 @@ fn reflow_elements(
                         b.end_line();
                     } else {
                         b.flush_atom();
-                        if cx.wrap == WrapMode::Minimal {
+                        if cx.wrap == WrapMode::Stable {
                             b.prefer_next_break();
                         }
                     }
@@ -3709,7 +3709,7 @@ fn lower_bracketed(node: &SyntaxNode, open: SyntaxKind, close: SyntaxKind, cx: L
     // group (the only soft break a rigid `lower_element_stream` body would expose).
     // Optional `[…]` bodies and the non-reflow modes keep the generic stream.
     let body =
-        if matches!(cx.wrap, WrapMode::Reflow | WrapMode::Minimal) && open == SyntaxKind::L_BRACE {
+        if matches!(cx.wrap, WrapMode::Reflow | WrapMode::Stable) && open == SyntaxKind::L_BRACE {
             reflow_elements(body_elements.into_iter(), cx, ReflowKind::Statement)
         } else {
             Ir::concat(lower_element_stream(body_elements.into_iter(), cx))

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -343,6 +343,7 @@ fn format_root(
         // Resolved here (never `Auto` past this point), so per-file-kind wrap
         // defaults and library callers get the derivation for free.
         math_wrap: ctx.style().math_wrap.resolve(ctx.style().wrap),
+        wrap_target: ctx.style().effective_wrap_target(),
         signatures: Signatures::new(&user),
         expl3_regions: &regions,
         profile,
@@ -545,6 +546,9 @@ struct LowerCtx<'a> {
     /// Display-math break policy, pre-resolved against `wrap` in
     /// [`format_root`] — never [`MathWrap::Auto`] here.
     math_wrap: MathWrap,
+    /// Effective soft line target for [`WrapMode::Minimal`]. Already defaulted
+    /// and clamped against the hard width by [`FormatStyle`].
+    wrap_target: usize,
     signatures: Signatures<'a>,
     /// Sorted, non-overlapping byte ranges of the document's expl3 regions (see
     /// [`expl3_regions`]). Inside these, source whitespace is catcode-9 (ignored)
@@ -555,7 +559,7 @@ struct LowerCtx<'a> {
     /// The sentence-boundary profile (built-in language plus user no-break
     /// abbreviations) for the [`WrapMode::Sentence`]/[`WrapMode::Semantic`] modes.
     /// `Copy`, borrowing the merged slice owned by [`format_root`]. Never consulted
-    /// under [`WrapMode::Reflow`]/[`WrapMode::Preserve`], so an English default
+    /// under [`WrapMode::Reflow`]/[`WrapMode::Minimal`]/[`WrapMode::Preserve`], so an English default
     /// (see [`SentenceOptions::default`]) is harmless there.
     profile: ResolvedProfile<'a>,
     /// Range-formatting emission filter. When `Some`, only the [`SyntaxKind::ROOT`]
@@ -575,7 +579,7 @@ impl<'a> LowerCtx<'a> {
     fn wraps_prose(self) -> bool {
         matches!(
             self.wrap,
-            WrapMode::Reflow | WrapMode::Sentence | WrapMode::Semantic
+            WrapMode::Reflow | WrapMode::Minimal | WrapMode::Sentence | WrapMode::Semantic
         )
     }
 
@@ -613,8 +617,8 @@ impl<'a> LowerCtx<'a> {
 
 /// Lower a CST node to IR. Most nodes lower generically (see
 /// [`lower_element_stream`]); an [`SyntaxKind::ENVIRONMENT`] is special-cased to
-/// indent its body (see [`lower_environment`]), and under [`WrapMode::Reflow`] a
-/// [`SyntaxKind::PARAGRAPH`] is wrapped to the line width (see
+/// indent its body (see [`lower_environment`]), and under each prose-wrapping mode a
+/// [`SyntaxKind::PARAGRAPH`] is routed through its line policy (see
 /// [`lower_paragraph_reflow`]). The [`LowerCtx`] (wrap mode + signature overlay) is
 /// threaded through so it reaches every nested paragraph (including environment and
 /// group bodies).
@@ -934,10 +938,13 @@ const DTX_DOC_MARGIN: &str = "% ";
 /// One committed atom of a logical-line run: the printed [`Ir`] plus the atom's
 /// source `text`, retained so the [`WrapMode::Sentence`]/[`WrapMode::Semantic`]
 /// renderer can run sentence-boundary detection over the words. Under
-/// [`WrapMode::Reflow`] only the `ir` is used.
+/// [`WrapMode::Reflow`]/[`WrapMode::Minimal`] only the layout fields are used.
 struct RunAtom {
     ir: Ir,
     text: String,
+    /// Whether the gap immediately before this atom was a source newline. False
+    /// for the first atom and for ordinary inter-word whitespace.
+    preferred_break_before: bool,
 }
 
 /// How a completed logical-line run is rendered into a single segment.
@@ -946,6 +953,8 @@ enum RunRender<'a> {
     /// Greedy width fill (reflow): one [`Ir::fill`] over the run's atoms, the
     /// printer breaking word-by-word at the line width.
     Fill,
+    /// Source-break-aware optimal fill used by [`WrapMode::Minimal`].
+    Minimal { target: usize },
     /// One sentence per line (sentence/semantic): cut the run at sentence
     /// boundaries and lay each sentence flat (space-joined), separating sentences
     /// with a hard break. Width is ignored — a long sentence stays on one line.
@@ -1001,6 +1010,8 @@ struct LineBuilder<'a> {
     /// Glued pieces of the atom in progress (its [`Ir`] and its source text).
     atom: Vec<Ir>,
     atom_text: String,
+    /// Source-newline preference to attach to the next committed atom.
+    preferred_break_before_next: bool,
     /// Atoms of the current run (the current logical line).
     run: Vec<RunAtom>,
     /// Completed lines (fills/sentences and blocks), interleaved with `seps` at the
@@ -1023,6 +1034,7 @@ impl<'a> LineBuilder<'a> {
         Self {
             atom: Vec::new(),
             atom_text: String::new(),
+            preferred_break_before_next: false,
             run: Vec::new(),
             lines: Vec::new(),
             seps: Vec::new(),
@@ -1044,7 +1056,15 @@ impl<'a> LineBuilder<'a> {
             self.run.push(RunAtom {
                 ir: Ir::concat(self.atom.drain(..)),
                 text: std::mem::take(&mut self.atom_text),
+                preferred_break_before: std::mem::take(&mut self.preferred_break_before_next),
             });
+        }
+    }
+
+    /// Mark the next inter-atom gap as an authored line break.
+    fn prefer_next_break(&mut self) {
+        if !self.run.is_empty() {
+            self.preferred_break_before_next = true;
         }
     }
 
@@ -1101,6 +1121,14 @@ impl<'a> LineBuilder<'a> {
         let run = std::mem::take(&mut self.run);
         let body = match self.render {
             RunRender::Fill => Ir::fill(run.into_iter().map(|a| a.ir)),
+            RunRender::Minimal { target } => {
+                let preferred: Vec<bool> = run
+                    .iter()
+                    .skip(1)
+                    .map(|atom| atom.preferred_break_before)
+                    .collect();
+                Ir::preferred_fill(run.into_iter().map(|a| a.ir), preferred, target)
+            }
             RunRender::Sentence(profile) => render_sentences(run, profile),
         };
         let segment = match self.margin {
@@ -1142,6 +1170,9 @@ fn reflow_elements(
     // Sentence/semantic segmentation applies to *prose* runs; a `Statement` run is
     // code (a `\newcommand` body), so it keeps the width fill regardless of mode.
     let render = match cx.wrap {
+        WrapMode::Minimal if kind != ReflowKind::Statement => RunRender::Minimal {
+            target: cx.wrap_target,
+        },
         WrapMode::Sentence | WrapMode::Semantic if kind != ReflowKind::Statement => {
             RunRender::Sentence(cx.profile)
         }
@@ -1200,6 +1231,9 @@ fn reflow_elements(
                         b.end_line();
                     } else {
                         b.flush_atom();
+                        if cx.wrap == WrapMode::Minimal {
+                            b.prefer_next_break();
+                        }
                     }
                     line_all_commands = true;
                     line_has_content = false;
@@ -2397,7 +2431,7 @@ enum FlatItem {
 /// the body indent. The framing (`\begin`/`\end`, the indented body with
 /// leading/trailing `hard_line`) matches [`lower_environment`].
 ///
-/// Only reached under [`WrapMode::Reflow`] (see [`lower_node`]). Falls back to the
+/// Only reached under a prose-wrapping mode (see [`lower_node`]). Falls back to the
 /// plain [`lower_environment`] when the body has no `\item` to anchor on, so an
 /// unusual shape degrades to today's indented body rather than misformatting.
 fn lower_list_environment(node: &SyntaxNode, cx: LowerCtx<'_>) -> Ir {
@@ -3674,11 +3708,12 @@ fn lower_bracketed(node: &SyntaxNode, open: SyntaxKind, close: SyntaxKind, cx: L
     // width instead of forcing the printer to break the innermost nested prose
     // group (the only soft break a rigid `lower_element_stream` body would expose).
     // Optional `[…]` bodies and the non-reflow modes keep the generic stream.
-    let body = if cx.wrap == WrapMode::Reflow && open == SyntaxKind::L_BRACE {
-        reflow_elements(body_elements.into_iter(), cx, ReflowKind::Statement)
-    } else {
-        Ir::concat(lower_element_stream(body_elements.into_iter(), cx))
-    };
+    let body =
+        if matches!(cx.wrap, WrapMode::Reflow | WrapMode::Minimal) && open == SyntaxKind::L_BRACE {
+            reflow_elements(body_elements.into_iter(), cx, ReflowKind::Statement)
+        } else {
+            Ir::concat(lower_element_stream(body_elements.into_iter(), cx))
+        };
     let body = trim_trailing_break(trim_leading_break(body));
 
     if matches!(body, Ir::Nil) {

--- a/src/formatter/ir.rs
+++ b/src/formatter/ir.rs
@@ -116,6 +116,15 @@ pub(crate) enum Ir {
     /// (every `Line` flat or every `Line` broken), and a conditional group picks
     /// among whole-layout candidates — neither wraps word-by-word.
     Fill(Rc<[Ir]>),
+    /// A paragraph fill whose gaps remember which ones were authored newlines.
+    /// The printer selects a global minimum-cost layout: overflow first, then
+    /// short lines relative to `target`, changed authored breaks, displacement,
+    /// raggedness, and line count. `preferred.len() == atoms.len() - 1`.
+    PreferredFill {
+        atoms: Rc<[Ir]>,
+        preferred: Rc<[bool]>,
+        target: usize,
+    },
     /// Re-emit `prefix` at column 0 on every line `inner` produces. While the
     /// printer lays out `inner`, each line break (and the first line) writes
     /// `prefix` flush at the left margin immediately after the newline, and
@@ -249,6 +258,29 @@ impl Ir {
         }
     }
 
+    /// Build a source-break-aware paragraph fill. `preferred[i]` describes the
+    /// gap between atoms `i` and `i + 1`.
+    pub(crate) fn preferred_fill(
+        atoms: impl IntoIterator<Item = Ir>,
+        preferred: Vec<bool>,
+        target: usize,
+    ) -> Ir {
+        let atoms: Vec<Ir> = atoms
+            .into_iter()
+            .filter(|i| !matches!(i, Ir::Nil))
+            .collect();
+        debug_assert_eq!(preferred.len(), atoms.len().saturating_sub(1));
+        match atoms.len() {
+            0 => Ir::Nil,
+            1 => atoms.into_iter().next().unwrap(),
+            _ => Ir::PreferredFill {
+                atoms: atoms.into(),
+                preferred: preferred.into(),
+                target,
+            },
+        }
+    }
+
     pub(crate) fn indent(inner: Ir) -> Ir {
         Ir::Indent(Rc::new(inner))
     }
@@ -327,6 +359,7 @@ impl Ir {
             Ir::Group { .. } | Ir::ConditionalGroup(_) | Ir::ConditionalGroupAllLines(_) => true,
             Ir::Concat(items) => items.iter().any(Ir::contains_group),
             Ir::Fill(parts) => parts.iter().any(Ir::contains_group),
+            Ir::PreferredFill { atoms, .. } => atoms.iter().any(Ir::contains_group),
             Ir::Indent(inner) | Ir::Align(_, inner) => inner.contains_group(),
             Ir::MarginPrefix { inner, .. } => inner.contains_group(),
             Ir::IfBreak { flat, broken } => flat.contains_group() || broken.contains_group(),
@@ -368,6 +401,7 @@ impl Ir {
             // A fill's separators are soft `Line`s; only its atoms could carry a
             // forced break (none do under reflow lowering, but stay correct).
             Ir::Fill(parts) => parts.iter().any(Ir::contains_forced_break),
+            Ir::PreferredFill { atoms, .. } => atoms.iter().any(Ir::contains_forced_break),
             Ir::Indent(inner) | Ir::Align(_, inner) => inner.contains_forced_break(),
             Ir::MarginPrefix { inner, .. } => inner.contains_forced_break(),
             Ir::Group { inner, expand, .. } => *expand || inner.contains_forced_break(),

--- a/src/formatter/printer.rs
+++ b/src/formatter/printer.rs
@@ -1,7 +1,9 @@
 //! The layout engine: walks an [`Ir`] tree and renders it to a string, deciding
 //! for each [`Ir::Group`] whether it fits flat on the current line or must break.
 //!
-//! This is a language-agnostic Wadler/Prettier-style layout engine.
+//! This is a language-agnostic Wadler/Prettier-style layout engine. Alongside
+//! ordinary greedy fills it supports source-break-aware preferred fills whose
+//! gaps are selected by a global lexicographic cost.
 
 // `print_at` is part of the engine but unused by the identity lowering;
 // keep it ready for real rules.
@@ -9,6 +11,31 @@
 
 use super::ir::Ir;
 use super::style::FormatStyle;
+use std::rc::Rc;
+
+/// Lexicographic cost for a source-break-aware paragraph layout.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+struct LayoutCost {
+    overflow: usize,
+    underflow: usize,
+    changed_breaks: usize,
+    displacement: usize,
+    raggedness: usize,
+    lines: usize,
+}
+
+impl LayoutCost {
+    fn add(self, other: Self) -> Self {
+        Self {
+            overflow: self.overflow.saturating_add(other.overflow),
+            underflow: self.underflow.saturating_add(other.underflow),
+            changed_breaks: self.changed_breaks.saturating_add(other.changed_breaks),
+            displacement: self.displacement.saturating_add(other.displacement),
+            raggedness: self.raggedness.saturating_add(other.raggedness),
+            lines: self.lines.saturating_add(other.lines),
+        }
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -18,9 +45,8 @@ enum Mode {
 
 /// A unit of pending work on the printer's layout stack. Most IR nodes are a
 /// plain [`Cmd::Node`]; [`Ir::Fill`] is processed incrementally as a
-/// [`Cmd::Fill`] carrying the not-yet-laid-out remainder of its alternating
-/// `[atom, sep, …]` list, so each gap is decided one at a time (see
-/// [`Printer::step_fill`]).
+/// [`Cmd::Fill`], while [`Ir::PreferredFill`] carries the globally selected break
+/// plan through [`Cmd::PreferredFill`].
 enum Cmd<'a> {
     Node {
         indent: usize,
@@ -35,6 +61,14 @@ enum Cmd<'a> {
         indent: usize,
         mode: Mode,
         parts: &'a [Ir],
+        prefix: Option<&'a str>,
+    },
+    PreferredFill {
+        indent: usize,
+        mode: Mode,
+        atoms: &'a [Ir],
+        breaks: Rc<[bool]>,
+        index: usize,
         prefix: Option<&'a str>,
     },
 }
@@ -232,6 +266,39 @@ impl Printer {
                     self.step_fill(&w, indent, mode, parts, prefix, &mut stack);
                     continue;
                 }
+                Cmd::PreferredFill {
+                    indent,
+                    mode,
+                    atoms,
+                    breaks,
+                    index,
+                    prefix,
+                } => {
+                    if index > 0 {
+                        if mode == Mode::Break && breaks[index - 1] {
+                            w.newline(indent, prefix);
+                        } else {
+                            w.write_text(" ");
+                        }
+                    }
+                    if index + 1 < atoms.len() {
+                        stack.push(Cmd::PreferredFill {
+                            indent,
+                            mode,
+                            atoms,
+                            breaks: Rc::clone(&breaks),
+                            index: index + 1,
+                            prefix,
+                        });
+                    }
+                    stack.push(Cmd::Node {
+                        indent,
+                        mode: Mode::Flat,
+                        node: &atoms[index],
+                        prefix,
+                    });
+                    continue;
+                }
             };
             match node {
                 Ir::Nil => {}
@@ -255,6 +322,32 @@ impl Printer {
                     parts: &parts[..],
                     prefix,
                 }),
+                Ir::PreferredFill {
+                    atoms,
+                    preferred,
+                    target,
+                } => {
+                    let breaks = if mode == Mode::Flat {
+                        vec![false; atoms.len().saturating_sub(1)].into()
+                    } else {
+                        self.minimal_breaks(
+                            w.current_col(),
+                            indent,
+                            prefix,
+                            atoms,
+                            preferred,
+                            *target,
+                        )
+                    };
+                    stack.push(Cmd::PreferredFill {
+                        indent,
+                        mode,
+                        atoms,
+                        breaks,
+                        index: 0,
+                        prefix,
+                    });
+                }
                 Ir::Indent(inner) => {
                     stack.push(Cmd::Node {
                         indent: indent + self.indent_unit,
@@ -357,6 +450,135 @@ impl Printer {
             }
         }
         w.out
+    }
+
+    /// Choose all breaks for a [`Ir::PreferredFill`] together. Authored breaks are
+    /// stable once a line reaches `target` (or the next atom would reach it), but
+    /// overflow always wins; ties minimize changed breaks and their displacement.
+    fn minimal_breaks(
+        &self,
+        first_col: usize,
+        indent: usize,
+        prefix: Option<&str>,
+        atoms: &[Ir],
+        preferred: &[bool],
+        target: usize,
+    ) -> Rc<[bool]> {
+        let n = atoms.len();
+        if n < 2 {
+            return Vec::new().into();
+        }
+        debug_assert_eq!(preferred.len(), n - 1);
+
+        let widths: Vec<usize> = atoms
+            .iter()
+            .map(|atom| {
+                self.flat_width(atom)
+                    .unwrap_or(self.line_width.saturating_add(1))
+            })
+            .collect();
+        let mut sums = Vec::with_capacity(n + 1);
+        sums.push(0usize);
+        for &width in &widths {
+            sums.push(sums.last().copied().unwrap_or(0).saturating_add(width));
+        }
+        // Source positions of the gaps in the normalized, space-joined run. They
+        // are used only to rank displacement from the nearest authored anchor.
+        let gap_positions: Vec<usize> = (0..n - 1)
+            .map(|gap| sums[gap + 1].saturating_add(gap + 1))
+            .collect();
+        let authored_positions: Vec<usize> = preferred
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &is_authored)| is_authored.then_some(gap_positions[i]))
+            .collect();
+        let continuation_col = prefix.map_or(indent, |p| p.chars().count());
+        let target = target.clamp(1, self.line_width.max(1));
+
+        let mut costs: Vec<Option<LayoutCost>> = vec![None; n + 1];
+        let mut previous: Vec<Option<usize>> = vec![None; n + 1];
+        costs[0] = Some(LayoutCost::default());
+
+        for start in 0..n {
+            let Some(base_cost) = costs[start] else {
+                continue;
+            };
+            let base_col = if start == 0 {
+                first_col
+            } else {
+                continuation_col
+            };
+            let mut saw_non_overflow = false;
+            for end in start + 1..=n {
+                let content_width = sums[end]
+                    .saturating_sub(sums[start])
+                    .saturating_add(end.saturating_sub(start + 1));
+                let length = base_col.saturating_add(content_width);
+                let next_length =
+                    (end < n).then(|| length.saturating_add(1).saturating_add(widths[end]));
+                let final_line = end == n;
+                let overflow = length.saturating_sub(self.line_width);
+                if overflow == 0 {
+                    saw_non_overflow = true;
+                } else if saw_non_overflow {
+                    break;
+                }
+
+                let removed_anchors = if end > start + 1 {
+                    preferred[start..end - 1]
+                        .iter()
+                        .filter(|&&is_authored| is_authored)
+                        .count()
+                } else {
+                    0
+                };
+                let new_break = usize::from(!final_line && !preferred[end - 1]);
+                let displacement = if new_break == 0 || authored_positions.is_empty() {
+                    0
+                } else {
+                    authored_positions
+                        .iter()
+                        .map(|&anchor| anchor.abs_diff(gap_positions[end - 1]))
+                        .min()
+                        .unwrap_or(0)
+                };
+                let underflow = if final_line
+                    || length >= target
+                    || next_length.is_some_and(|next| next >= target)
+                {
+                    0
+                } else {
+                    target - length
+                };
+                let segment = LayoutCost {
+                    overflow,
+                    underflow,
+                    changed_breaks: removed_anchors + new_break,
+                    displacement,
+                    raggedness: if final_line {
+                        0
+                    } else {
+                        target.abs_diff(length)
+                    },
+                    lines: 1,
+                };
+                let candidate = base_cost.add(segment);
+                if costs[end].is_none_or(|cost| candidate < cost) {
+                    costs[end] = Some(candidate);
+                    previous[end] = Some(start);
+                }
+            }
+        }
+
+        let mut breaks = vec![false; n - 1];
+        let mut cursor = n;
+        while let Some(prior) = previous[cursor] {
+            if prior > 0 {
+                breaks[prior - 1] = true;
+            }
+            cursor = prior;
+        }
+        breaks.into()
     }
 
     /// One step of laying out an [`Ir::Fill`] — the Wadler/Prettier greedy fill.
@@ -465,6 +687,10 @@ impl Printer {
                 Ir::Line => total += 1,
                 Ir::Concat(items) => stack.extend(items.iter()),
                 Ir::Fill(parts) => stack.extend(parts.iter()),
+                Ir::PreferredFill { atoms, .. } => {
+                    total = total.saturating_add(atoms.len().saturating_sub(1));
+                    stack.extend(atoms.iter());
+                }
                 Ir::Indent(inner) | Ir::Align(_, inner) => stack.push(inner),
                 Ir::MarginPrefix { inner, .. } => stack.push(inner),
                 Ir::IfBreak { flat, .. } => stack.push(flat),
@@ -638,6 +864,16 @@ impl Printer {
                         stack.push(item);
                     }
                 }
+                Ir::PreferredFill { atoms, .. } => {
+                    let gaps = atoms.len().saturating_sub(1);
+                    if gaps > remaining {
+                        return false;
+                    }
+                    remaining -= gaps;
+                    for atom in atoms.iter().rev() {
+                        stack.push(atom);
+                    }
+                }
             }
         }
         true
@@ -707,6 +943,15 @@ impl Printer {
                         stack.push(item);
                     }
                 }
+                Ir::PreferredFill { atoms, .. } => {
+                    col = col.saturating_add(atoms.len().saturating_sub(1));
+                    if col > self.line_width {
+                        return false;
+                    }
+                    for atom in atoms.iter().rev() {
+                        stack.push(atom);
+                    }
+                }
             }
         }
         // Phase 2: the rest of the line, each command in its decided mode, until
@@ -733,6 +978,11 @@ impl Printer {
                     for part in parts.iter().rev() {
                         work.push((*mode, part));
                     }
+                }
+                Cmd::PreferredFill {
+                    mode, atoms, index, ..
+                } => {
+                    work.push((*mode, &atoms[*index]));
                 }
             }
         }
@@ -788,6 +1038,15 @@ impl Printer {
                 Ir::Fill(parts) => {
                     for item in parts.iter().rev() {
                         work.push((mode, item));
+                    }
+                }
+                Ir::PreferredFill { atoms, .. } => {
+                    col = col.saturating_add(atoms.len().saturating_sub(1));
+                    if col > self.line_width {
+                        return false;
+                    }
+                    for atom in atoms.iter().rev() {
+                        work.push((Mode::Flat, atom));
                     }
                 }
             }
@@ -876,6 +1135,15 @@ impl Printer {
                 Ir::Fill(parts) => {
                     for item in parts.iter().rev() {
                         stack.push((mode, item));
+                    }
+                }
+                Ir::PreferredFill { atoms, .. } => {
+                    col = col.saturating_add(atoms.len().saturating_sub(1));
+                    if col > self.line_width {
+                        return false;
+                    }
+                    for atom in atoms.iter().rev() {
+                        stack.push((Mode::Flat, atom));
                     }
                 }
                 Ir::ConditionalGroup(cands) | Ir::ConditionalGroupAllLines(cands) => {
@@ -1086,6 +1354,13 @@ mod tests {
         let printer = Printer::new(FormatStyle::default());
         let ir = Ir::fill([Ir::text("a"), Ir::text("b"), Ir::text("c")]);
         assert_eq!(printer.print(&ir), "a b c");
+    }
+
+    #[test]
+    fn fill_drops_nil_atoms_without_phantom_spaces() {
+        let printer = Printer::new(FormatStyle::default());
+        let ir = Ir::fill([Ir::text("a"), Ir::Nil, Ir::text("b")]);
+        assert_eq!(printer.print(&ir), "a b");
     }
 
     #[test]

--- a/src/formatter/printer.rs
+++ b/src/formatter/printer.rs
@@ -330,7 +330,7 @@ impl Printer {
                     let breaks = if mode == Mode::Flat {
                         vec![false; atoms.len().saturating_sub(1)].into()
                     } else {
-                        self.minimal_breaks(
+                        self.stable_breaks(
                             w.current_col(),
                             indent,
                             prefix,
@@ -455,7 +455,7 @@ impl Printer {
     /// Choose all breaks for a [`Ir::PreferredFill`] together. Authored breaks are
     /// stable once a line reaches `target` (or the next atom would reach it), but
     /// overflow always wins; ties minimize changed breaks and their displacement.
-    fn minimal_breaks(
+    fn stable_breaks(
         &self,
         first_col: usize,
         indent: usize,

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -17,6 +17,9 @@ pub enum WrapMode {
     /// word would not fit. The default.
     #[default]
     Reflow,
+    /// Preserve acceptable authored breaks and redistribute only the smallest
+    /// region needed to satisfy `line_width` and approach `wrap_target`.
+    Minimal,
     /// Wrap after each sentence (one sentence per line). Line width is ignored — a
     /// long sentence stays on one line.
     Sentence,
@@ -76,6 +79,9 @@ pub struct FormatStyle {
     pub indent_width: usize,
     pub wrap: WrapMode,
     pub math_wrap: MathWrap,
+    /// Soft line-length target used only by [`WrapMode::Minimal`]. `None` uses
+    /// ten columns below `line_width` (clamped to at least one column).
+    pub wrap_target: Option<usize>,
 }
 
 impl Default for FormatStyle {
@@ -85,6 +91,17 @@ impl Default for FormatStyle {
             indent_width: 2,
             wrap: WrapMode::default(),
             math_wrap: MathWrap::default(),
+            wrap_target: None,
         }
+    }
+}
+
+impl FormatStyle {
+    /// Effective soft target for minimal wrapping. It can never exceed the hard
+    /// line width, including for styles constructed directly by API callers.
+    pub(crate) fn effective_wrap_target(self) -> usize {
+        self.wrap_target
+            .unwrap_or_else(|| self.line_width.saturating_sub(10).max(1))
+            .clamp(1, self.line_width.max(1))
     }
 }

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -18,8 +18,10 @@ pub enum WrapMode {
     #[default]
     Reflow,
     /// Preserve acceptable authored breaks and redistribute only the smallest
-    /// region needed to satisfy `line_width` and approach `wrap_target`.
-    Minimal,
+    /// region needed to satisfy `line_width` and approach the soft equilibrium
+    /// target ([`FormatStyle::stable_wrap_target`]). Aimed at keeping revision
+    /// diffs small: a small prose edit perturbs the smallest possible region.
+    Stable,
     /// Wrap after each sentence (one sentence per line). Line width is ignored — a
     /// long sentence stays on one line.
     Sentence,
@@ -79,9 +81,6 @@ pub struct FormatStyle {
     pub indent_width: usize,
     pub wrap: WrapMode,
     pub math_wrap: MathWrap,
-    /// Soft line-length target used only by [`WrapMode::Minimal`]. `None` uses
-    /// ten columns below `line_width` (clamped to at least one column).
-    pub wrap_target: Option<usize>,
 }
 
 impl Default for FormatStyle {
@@ -91,17 +90,27 @@ impl Default for FormatStyle {
             indent_width: 2,
             wrap: WrapMode::default(),
             math_wrap: MathWrap::default(),
-            wrap_target: None,
         }
     }
 }
 
+/// Columns below `line_width` that [`WrapMode::Stable`] aims for as its soft
+/// equilibrium target. A larger offset widens the acceptable band
+/// `[target, line_width]`, so more authored breaks fall inside it and survive
+/// untouched — which is the whole point of the mode (minimize revision diffs).
+/// Deliberately *not* configurable yet: keeping the config surface minimal (see
+/// the maintainer discussion on the PR). Promote this to a `FormatStyle`/config
+/// field if a concrete user need for tuning it appears.
+pub(crate) const STABLE_WRAP_TARGET_OFFSET: usize = 15;
+
 impl FormatStyle {
-    /// Effective soft target for minimal wrapping. It can never exceed the hard
-    /// line width, including for styles constructed directly by API callers.
-    pub(crate) fn effective_wrap_target(self) -> usize {
-        self.wrap_target
-            .unwrap_or_else(|| self.line_width.saturating_sub(10).max(1))
+    /// Soft equilibrium target for [`WrapMode::Stable`]: [`STABLE_WRAP_TARGET_OFFSET`]
+    /// columns below the hard `line_width`, clamped to at least one column. It can
+    /// never exceed the hard width, including for styles built directly by API
+    /// callers.
+    pub(crate) fn stable_wrap_target(self) -> usize {
+        self.line_width
+            .saturating_sub(STABLE_WRAP_TARGET_OFFSET)
             .clamp(1, self.line_width.max(1))
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -6880,6 +6880,20 @@ mod tests {
     }
 
     #[test]
+    fn resolve_settings_minimal_wrap_and_target_from_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("badness.toml"),
+            "[format]\nline-width = 100\nwrap = \"minimal\"\nwrap-target = 85\n",
+        )
+        .expect("write config");
+        let mut state = state_with_editor(EditorSettings::default());
+        let resolved = state.resolve_settings(&file_uri_in(dir.path()));
+        assert_eq!(resolved.wrap_override, Some(WrapMode::Minimal));
+        assert_eq!(resolved.style.wrap_target, Some(85));
+    }
+
+    #[test]
     fn resolve_settings_applies_lint_selection() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -6880,17 +6880,16 @@ mod tests {
     }
 
     #[test]
-    fn resolve_settings_minimal_wrap_and_target_from_config() {
+    fn resolve_settings_stable_wrap_from_config() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             dir.path().join("badness.toml"),
-            "[format]\nline-width = 100\nwrap = \"minimal\"\nwrap-target = 85\n",
+            "[format]\nline-width = 100\nwrap = \"stable\"\n",
         )
         .expect("write config");
         let mut state = state_with_editor(EditorSettings::default());
         let resolved = state.resolve_settings(&file_uri_in(dir.path()));
-        assert_eq!(resolved.wrap_override, Some(WrapMode::Minimal));
-        assert_eq!(resolved.style.wrap_target, Some(85));
+        assert_eq!(resolved.wrap_override, Some(WrapMode::Stable));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ use smol_str::SmolStr;
 fn wrap_mode(arg: WrapArg) -> WrapMode {
     match arg {
         WrapArg::Reflow => WrapMode::Reflow,
+        WrapArg::Minimal => WrapMode::Minimal,
         WrapArg::Sentence => WrapMode::Sentence,
         WrapArg::Semantic => WrapMode::Semantic,
         WrapArg::Preserve => WrapMode::Preserve,
@@ -80,6 +81,7 @@ fn main() -> ExitCode {
             check,
             stdin_filepath,
             line_width,
+            wrap_target,
             indent_width,
             wrap,
             math_wrap,
@@ -309,8 +311,9 @@ const STARTER_CONFIG: &str = "\
 
 [format]
 # line-width = 80
+# wrap-target = 70  # soft target used only by wrap = \"minimal\"
 # indent-width = 2
-# wrap = \"reflow\"  # reflow | sentence | semantic | preserve
+# wrap = \"reflow\"  # reflow | minimal | sentence | semantic | preserve
                      # omit to use each file kind's default
                      # (.tex -> reflow, .sty/.cls/.dtx/.ins -> preserve)
 # math-wrap = \"auto\"  # auto | preserve | single-line | break

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use smol_str::SmolStr;
 fn wrap_mode(arg: WrapArg) -> WrapMode {
     match arg {
         WrapArg::Reflow => WrapMode::Reflow,
-        WrapArg::Minimal => WrapMode::Minimal,
+        WrapArg::Stable => WrapMode::Stable,
         WrapArg::Sentence => WrapMode::Sentence,
         WrapArg::Semantic => WrapMode::Semantic,
         WrapArg::Preserve => WrapMode::Preserve,
@@ -81,7 +81,6 @@ fn main() -> ExitCode {
             check,
             stdin_filepath,
             line_width,
-            wrap_target,
             indent_width,
             wrap,
             math_wrap,
@@ -311,9 +310,8 @@ const STARTER_CONFIG: &str = "\
 
 [format]
 # line-width = 80
-# wrap-target = 70  # soft target used only by wrap = \"minimal\"
 # indent-width = 2
-# wrap = \"reflow\"  # reflow | minimal | sentence | semantic | preserve
+# wrap = \"reflow\"  # reflow | stable | sentence | semantic | preserve
                      # omit to use each file kind's default
                      # (.tex -> reflow, .sty/.cls/.dtx/.ins -> preserve)
 # math-wrap = \"auto\"  # auto | preserve | single-line | break

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -961,16 +961,17 @@ fn preserve_keeps_author_breaks_while_reflow_joins() {
 }
 
 #[test]
-fn minimal_preserves_an_equilibrium_break_that_reflow_removes() {
+fn stable_preserves_an_equilibrium_break_that_reflow_removes() {
+    // The soft target is `line_width - 15` (see `FormatStyle::stable_wrap_target`),
+    // so a width of 40 targets column 25.
     let input = "Alpha beta gamma delta epsilon.\nZeta eta theta iota kappa lambda.\n";
-    let minimal = FormatStyle {
+    let stable = FormatStyle {
         line_width: 40,
-        wrap_target: Some(30),
-        wrap: WrapMode::Minimal,
+        wrap: WrapMode::Stable,
         ..FormatStyle::default()
     };
     assert_eq!(
-        format_with_style(input, minimal).expect("minimal formats"),
+        format_with_style(input, stable).expect("stable formats"),
         input,
         "an authored break at the soft target must remain stable"
     );
@@ -988,34 +989,34 @@ fn minimal_preserves_an_equilibrium_break_that_reflow_removes() {
 }
 
 #[test]
-fn minimal_repairs_overflow_locally_and_is_idempotent() {
+fn stable_repairs_overflow_locally_and_is_idempotent() {
+    // Width 60 targets column 45 (`line_width - 15`).
     let input = "This stable opening line reaches the target today.\n\
 This edited middle line is now much too long for the configured hard width here.\n\
 This following boundary reaches the target safely today.\n";
     let style = FormatStyle {
         line_width: 60,
-        wrap_target: Some(50),
-        wrap: WrapMode::Minimal,
+        wrap: WrapMode::Stable,
         ..FormatStyle::default()
     };
-    let formatted = format_with_style(input, style).expect("minimal formats");
+    let formatted = format_with_style(input, style).expect("stable formats");
     assert!(
         formatted.starts_with("This stable opening line reaches the target today.\n"),
         "the preceding equilibrium boundary should remain fixed: {formatted:?}"
     );
     assert!(
         formatted.lines().all(|line| line.chars().count() <= 60),
-        "minimal wrapping must honor the hard width: {formatted:?}"
+        "stable wrapping must honor the hard width: {formatted:?}"
     );
     assert_eq!(
         format_with_style(&formatted, style).expect("reformat"),
         formatted,
-        "minimal wrapping must be idempotent"
+        "stable wrapping must be idempotent"
     );
 }
 
 #[test]
-fn minimal_rebalances_only_unequilibrated_regions() {
+fn stable_rebalances_only_unequilibrated_regions() {
     let input = "The opening line is already safely within the accepted range today.\n\
 This edited middle line has become too long for the configured width here.\n\
 while this following line can donate some nearby space today.\n\
@@ -1032,18 +1033,116 @@ This second opening line is also an acceptable stable anchor today.\n\
 A shortened line now needs a few more nearby words. from\n\
 this following line which has enough content to share with it today.\n\
 The final short line remains a valid paragraph ending.\n";
+    // Width 70 targets column 55 (`line_width - 15`).
     let style = FormatStyle {
         line_width: 70,
-        wrap_target: Some(60),
-        wrap: WrapMode::Minimal,
+        wrap: WrapMode::Stable,
         ..FormatStyle::default()
     };
-    let formatted = format_with_style(input, style).expect("minimal formats");
+    let formatted = format_with_style(input, style).expect("stable formats");
     assert_eq!(formatted, expected);
     assert_eq!(
         format_with_style(&formatted, style).expect("reformat"),
         formatted
     );
+}
+
+/// Stable wrapping claims idempotence. The cost model is idempotent by
+/// construction (a solver output `b` is the unique global lex-min once fed back
+/// as the `preferred` set), so the only residual risk is parse-stability: that
+/// the reformatted text re-lexes to the same atoms and run segmentation. This
+/// fuzzes that empirically over many pseudo-random prose paragraphs, widths, and
+/// authored-break placements, asserting `fmt(fmt(x)) == fmt(x)`, the hard-width
+/// bound (modulo unbreakable long words), and losslessness of the output.
+#[test]
+fn stable_wrapping_is_idempotent_over_random_prose() {
+    // A tiny deterministic LCG (Numerical Recipes constants) — no dev-dep on a
+    // PRNG crate, and reproducible across platforms/runs.
+    struct Lcg(u64);
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            self.0 >> 16
+        }
+        fn below(&mut self, bound: usize) -> usize {
+            (self.next() as usize) % bound.max(1)
+        }
+    }
+
+    // Build a paragraph of random words separated by a space or a newline, with a
+    // sprinkling of blank-line paragraph breaks. Words are lowercase-letter runs so
+    // they never re-lex into something exotic (no commands, math, or comments).
+    fn random_prose(rng: &mut Lcg) -> String {
+        let mut out = String::new();
+        let paragraphs = 1 + rng.below(3);
+        for p in 0..paragraphs {
+            if p > 0 {
+                out.push_str("\n\n");
+            }
+            let words = 4 + rng.below(40);
+            for w in 0..words {
+                if w > 0 {
+                    // Roughly one in three gaps is an authored newline.
+                    out.push(if rng.below(3) == 0 { '\n' } else { ' ' });
+                }
+                let len = 1 + rng.below(12);
+                for _ in 0..len {
+                    out.push((b'a' + rng.below(26) as u8) as char);
+                }
+            }
+        }
+        out.push('\n');
+        out
+    }
+
+    let mut rng = Lcg(0x1234_5678_9abc_def0);
+    for case in 0..400 {
+        let input = random_prose(&mut rng);
+        // Vary the hard width; the soft target rides along at `width - 10`.
+        for &line_width in &[24usize, 40, 60, 72, 90] {
+            let style = FormatStyle {
+                line_width,
+                wrap: WrapMode::Stable,
+                ..FormatStyle::default()
+            };
+            let once = format_with_style(&input, style)
+                .unwrap_or_else(|e| panic!("case {case} @ {line_width}: format failed: {e:?}"));
+            let twice = format_with_style(&once, style)
+                .unwrap_or_else(|e| panic!("case {case} @ {line_width}: reformat failed: {e:?}"));
+            assert_eq!(
+                twice, once,
+                "stable wrap not idempotent (case {case} @ width {line_width})\ninput:  {input:?}\nonce:   {once:?}\ntwice:  {twice:?}"
+            );
+
+            // Hard width holds except where a single unbreakable word exceeds it.
+            for line in once.lines() {
+                let cols = line.chars().count();
+                let widest_word = line
+                    .split_whitespace()
+                    .map(|w| w.chars().count())
+                    .max()
+                    .unwrap_or(0);
+                assert!(
+                    cols <= line_width || widest_word > line_width,
+                    "line over hard width with a breakable layout (case {case} @ {line_width}): {line:?}"
+                );
+            }
+
+            // The output is a clean, lossless document.
+            assert!(
+                parse(&once).errors.is_empty(),
+                "stable output should parse cleanly (case {case} @ {line_width}): {once:?}"
+            );
+            assert_eq!(
+                reconstruct(&once),
+                once,
+                "stable output should round-trip losslessly (case {case} @ {line_width})"
+            );
+        }
+    }
 }
 
 /// A collapsible, inline-flagged command (the cite family) formats identically

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -960,6 +960,92 @@ fn preserve_keeps_author_breaks_while_reflow_joins() {
     );
 }
 
+#[test]
+fn minimal_preserves_an_equilibrium_break_that_reflow_removes() {
+    let input = "Alpha beta gamma delta epsilon.\nZeta eta theta iota kappa lambda.\n";
+    let minimal = FormatStyle {
+        line_width: 40,
+        wrap_target: Some(30),
+        wrap: WrapMode::Minimal,
+        ..FormatStyle::default()
+    };
+    assert_eq!(
+        format_with_style(input, minimal).expect("minimal formats"),
+        input,
+        "an authored break at the soft target must remain stable"
+    );
+
+    let reflow = FormatStyle {
+        line_width: 40,
+        wrap: WrapMode::Reflow,
+        ..FormatStyle::default()
+    };
+    assert_ne!(
+        format_with_style(input, reflow).expect("reflow formats"),
+        input,
+        "canonical reflow should not prefer the authored boundary"
+    );
+}
+
+#[test]
+fn minimal_repairs_overflow_locally_and_is_idempotent() {
+    let input = "This stable opening line reaches the target today.\n\
+This edited middle line is now much too long for the configured hard width here.\n\
+This following boundary reaches the target safely today.\n";
+    let style = FormatStyle {
+        line_width: 60,
+        wrap_target: Some(50),
+        wrap: WrapMode::Minimal,
+        ..FormatStyle::default()
+    };
+    let formatted = format_with_style(input, style).expect("minimal formats");
+    assert!(
+        formatted.starts_with("This stable opening line reaches the target today.\n"),
+        "the preceding equilibrium boundary should remain fixed: {formatted:?}"
+    );
+    assert!(
+        formatted.lines().all(|line| line.chars().count() <= 60),
+        "minimal wrapping must honor the hard width: {formatted:?}"
+    );
+    assert_eq!(
+        format_with_style(&formatted, style).expect("reformat"),
+        formatted,
+        "minimal wrapping must be idempotent"
+    );
+}
+
+#[test]
+fn minimal_rebalances_only_unequilibrated_regions() {
+    let input = "The opening line is already safely within the accepted range today.\n\
+This edited middle line has become too long for the configured width here.\n\
+while this following line can donate some nearby space today.\n\
+Finally this boundary should remain exactly where it is.\n\n\
+This second opening line is also an acceptable stable anchor today.\n\
+A shortened line now needs a few more nearby words.\n\
+from this following line which has enough content to share with it today.\n\
+The final short line remains a valid paragraph ending.\n";
+    let expected = "The opening line is already safely within the accepted range today.\n\
+This edited middle line has become too long for the configured width\n\
+here. while this following line can donate some nearby space today.\n\
+Finally this boundary should remain exactly where it is.\n\n\
+This second opening line is also an acceptable stable anchor today.\n\
+A shortened line now needs a few more nearby words. from\n\
+this following line which has enough content to share with it today.\n\
+The final short line remains a valid paragraph ending.\n";
+    let style = FormatStyle {
+        line_width: 70,
+        wrap_target: Some(60),
+        wrap: WrapMode::Minimal,
+        ..FormatStyle::default()
+    };
+    let formatted = format_with_style(input, style).expect("minimal formats");
+    assert_eq!(formatted, expected);
+    assert_eq!(
+        format_with_style(&formatted, style).expect("reformat"),
+        formatted
+    );
+}
+
 /// A collapsible, inline-flagged command (the cite family) formats identically
 /// regardless of how the author broke its key list across source lines: the same
 /// meaning must yield the same output (determinism). The single-line form is the


### PR DESCRIPTION
## Summary

- add a `minimal` paragraph wrap mode that preserves acceptable authored breaks
- add a source-aware `PreferredFill` formatter IR and global lexicographic layout selection
- expose `wrap-target` through configuration, CLI, and LSP resolution, defaulting to `line-width - 10`
- document the cost model, behavior, configuration, and revision-workflow use case
- add regression coverage for equilibrium preservation, local overflow repair, idempotence, and generic fill invariants

## Why

Canonical reflow can create broad source diffs after a small prose edit. The minimal mode treats authored newlines as preferred anchors while retaining `line-width` as the hard constraint and using `wrap-target` as a soft equilibrium point. This keeps manuscript revision diffs focused without moving layout decisions outside the formatter engine.

## User impact

Users can select the mode with:

```toml
[format]
line-width = 100
wrap = "minimal"
wrap-target = 85
```

or with `badness format --wrap minimal --wrap-target 85`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (1,064 library tests plus integration suites)
- `cargo clippy --all-targets --all-features -- -D warnings`
