### PR TITLE
docs(smoke-test): state the out-of-scope bar and teach triage the allowlist

### DIFF
--- a/.claude/skills/smoke-test-triage/SKILL.md
+++ b/.claude/skills/smoke-test-triage/SKILL.md
@@ -27,6 +27,15 @@ especially idempotency and losslessness regressions.
    - badness commit/version used by the scan
    - report excerpt and the approximate diff start line
 
+   Then **check the `ALLOWLIST` in `.github/workflows/smoke-test.yml`** before
+   doing any work. It holds `repo|path|type` entries for failures already
+   triaged as out of scope, and matching failures are suppressed from issue
+   filing. An issue naming an already-listed file means the scan predates the
+   entry — confirm and close rather than re-triaging it. The issue's sample
+   file is only the *first* failure in its bucket, so scan the whole repo
+   (`badness debug format --checks all --report .`) and triage by root cause;
+   the named sample is often not the most actionable one.
+
 2. Reproduce in a local clone of the target repository:
    - the issue's `logs/…` paths (sample log, report, and the idempotency
      `input`/`once`/`twice` dumps) are relative to the run artifact; fetch it
@@ -77,10 +86,39 @@ especially idempotency and losslessness regressions.
      rewrites must be meaning-preserving and reach a fixed point on the
      second pass.
    - **`format-error` ⇒ the formatter refused the input** (parse diagnostics
-     or an unsupported construct). Run `badness parse <file>` and read the
-     errors: either the parser mis-parses valid LaTeX (fix the grammar or
-     recovery; see the recovery anchors in AGENTS.md decision #5) or the file
-     is genuinely broken upstream (record it, no badness fix needed).
+     or an unsupported construct). Run `badness parse <file>` (diagnostics go
+     to **stderr**) and read the errors. Diagnostics cascade, so triage the
+     *earliest* error in each file — the rest are usually its fallout. Three
+     outcomes: the parser mis-parses valid LaTeX (fix the grammar or recovery;
+     see the recovery anchors in AGENTS.md decision #5), the file is genuinely
+     broken upstream, or the file is **statically unmodelable** — see below.
+   - **Statically unmodelable ⇒ out of scope; allowlist it, do not "fix" it.**
+     Some inputs cannot be parsed without running TeX, so no parser change is
+     correct. Fingerprints:
+     - *Structural catcode rebinding.* A region reassigns catcode 0/1/2/14 or
+       makes space active — doc.sty's `` \catcode`\!=\catcode`\% `` block (`|`
+       becomes the escape, `[`/`]` the group delimiters, `{`/`}` ordinary),
+       source2edoc.cls's `/gdef/oldc< … >`, pgf's bootstrap regions. Our CST's
+       structural vocabulary is built on `{`/`}`; a region that redefines it is
+       out of reach. Note `\makeatletter` is *not* this — it only changes
+       letter classification, which the lexer already handles.
+     - *Catcodes set through expansion.* `` \catcode`#1\active `` in a macro
+       body, or ``|catcode|expandafter`|special@escape@char|active`` — the
+       character is a macro parameter or expansion result, so no static reader
+       can resolve it. This is the proof that general catcode tracking is
+       impossible on real sources, not merely hard.
+     - *Balance hidden in a skipped conditional.* `\iffalse}\fi` /
+       `\iffalse{\fi` editor-balance tricks (docstrip.dtx, ltdefns.dtx).
+     - *Closed elsewhere.* A document whose `\end{document}` arrives by macro
+       expansion, or a fragment relying on a parent preamble's catcode and
+       short-verb state (the pgfmanual `\input` chunks).
+     Record these in the `ALLOWLIST` in `.github/workflows/smoke-test.yml` as
+     `repo|path|type`, grouped under a comment naming the root cause and the
+     issue. Only the named type is suppressed, so the file still reports if it
+     later fails a *different* way — an allowlist entry can never mask a new
+     regression. Be strict about what qualifies: a real modeling gap you simply
+     have not fixed yet is **not** out of scope, and allowlisting it buries the
+     work. When in doubt, leave it failing and say so in the report.
    - **`timeout` ⇒ a hang or pathological slowness.** Reproduce with the
      `/profile` skill's micro-bench; never-infinite-loop on unexpected input
      is a parser invariant.
@@ -121,6 +159,16 @@ especially idempotency and losslessness regressions.
      - `cargo fmt`
    - for parser/CST changes, also run `/parse-compat` (or `task parse-compat`)
      and triage any new divergence
+   - measure the fix against the **whole** target repo, not just the sample:
+     build a baseline binary (`git stash && cargo build --release`, copy it
+     aside, restore) and compare per-file diagnostic counts before/after. A
+     parser gate that fixes one shape routinely makes another *worse*, and only
+     a per-file diff catches it. Report the count, and treat any file that
+     regressed as a blocker, not a footnote.
+   - drop any `ALLOWLIST` entry the fix makes stale (the file now simply passes
+     and records nothing). Leaving a stale entry means a future regression in
+     that file is silently suppressed — the one way the allowlist *can* mask a
+     real bug.
 
 ## Badness-specific guidance
 
@@ -144,4 +192,10 @@ When done, report:
 2. Minimal reproducer summary.
 3. Fixture(s) added/updated.
 4. Root cause and code path changed.
-5. Validation commands run and outcomes.
+5. Validation commands run and outcomes, including the before/after failure
+   count over the whole target repo and confirmation that no file regressed.
+6. What you did **not** fix: the remaining buckets by root cause, which were
+   allowlisted as out of scope (with the reason) and which are open modeling
+   gaps still worth work. Say plainly whether the issue can be closed or should
+   stay open — a scan issue is rarely one bug, and a partial fix reported as a
+   whole one is worse than no fix.

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,6 +41,20 @@ jobs:
       # regression. Keep this in sync with TODO.md's record-only roadmap items;
       # drop an entry the moment badness can handle the file (it then simply
       # passes and records nothing). See issue #60.
+      #
+      # The bar for an entry is *statically unmodelable*, not merely unfixed: no
+      # parser change could be correct, because reading the file needs a TeX
+      # engine. In practice that means structural catcode rebinding (catcode
+      # 0/1/2/14 or an active space — our CST's structural vocabulary is `{`/`}`,
+      # so a region that reassigns it is out of reach; `\makeatletter` is *not*
+      # this, it only changes letter classification), catcodes set through
+      # expansion (`\catcode`#1\active` in a macro body — the character is a
+      # parameter, so no static reader can resolve it), balance hidden in a
+      # skipped conditional (`\iffalse}\fi`), or a file closed by state that
+      # lives outside it (macro-expanded `\end{document}`, an `\input` fragment
+      # leaning on its parent's preamble). A real modeling gap we simply have
+      # not fixed yet does **not** belong here — allowlisting it buries the
+      # work. Group entries under a comment naming the root cause and issue.
       ALLOWLIST: |
         # Catcode-rebinding bootstrap files: general \catcode handling is an
         # explicit non-goal (AGENTS.md decision #1), so these stay format-error.
@@ -66,6 +80,13 @@ jobs:
         latex3/latex2e|base/docstrip.dtx|format-error
         latex3/latex2e|base/ltdefns.dtx|format-error
         latex3/latex2e|base/ltcmd.dtx|format-error
+        # source2edoc.cls closes doc.dtx's `oldcomments` from inside its own
+        # catcode-swapped region (`/gdef/oldc< \end{oldcomments}>`: `/` is the
+        # escape, `<`/`>` the group delimiters). preload.dtx's `xii}` closes a
+        # brace opened on a *different* docstrip guard variant, so only running
+        # docstrip's guard selection balances it. Issue #71.
+        latex3/latex2e|base/source2edoc.cls|format-error
+        latex3/latex2e|base/preload.dtx|format-error
         # ltfloat.dtx: a `\begin{oldcomments}` doc environment wraps commented-out
         # historical code with a deliberately unbalanced `\vbox{`; oldcomments is a
         # doc `comment`-like environment badness cannot know is opaque. Issue #71.


### PR DESCRIPTION
Follow-up to #75, refs #71.

## Why

The workflow already suppresses known non-actionable failures via its `ALLOWLIST`, but the triage skill never mentioned it existed. Triaging #71 therefore meant re-deriving buckets for files that were *already* recorded as out of scope — and the issue's named sample (`base/doc-2016-02-15.sty`) was already listed, so the whole investigation started from a file nothing could be done about.

`doc.sty` is also a good proof that general catcode handling has to stay a non-goal rather than a to-do. Two lines in it:

```tex
\catcode`#1\active                               % inside a macro body
|catcode|expandafter`|special@escape@char|active % char stored in a macro
```

In both, *which character* is being recatcoded isn't knowable statically. A tracker that guesses is the worst outcome: a wrong catcode silently changes what's code and what's comment, and neither the losslessness nor the idempotency oracle catches it (byte-preserving and stable, just wrong) — the same trap AGENTS.md already records for the expl3 toggles in #69.

## What

**Workflow** — give the allowlist an explicit bar instead of "known non-actionable": *statically unmodelable*, not merely unfixed. That means structural catcode rebinding (catcode 0/1/2/14 or an active space — our CST's structural vocabulary is `{`/`}`, so a region that reassigns it is out of reach; `\makeatletter` explicitly does **not** qualify, it only changes letter classification), catcodes set through expansion, balance hidden in a skipped conditional, or a file closed by state living outside it. With the guard against the obvious abuse: a real modeling gap we simply have not fixed does not belong there, because allowlisting it buries the work.

Adds the two latex2e files this triage confirmed unmodelable:

- `base/source2edoc.cls` — closes doc.dtx's `oldcomments` from inside its own catcode-swapped region (`/gdef/oldc< \end{oldcomments}>`: `/` is the escape, `<`/`>` the group delimiters)
- `base/preload.dtx` — `xii}` closes a brace opened on a *different* docstrip guard variant, so only running docstrip's guard selection balances it

**Skill** — five gaps, each one something that cost time on #71:

- check the allowlist *before* starting; an issue naming a listed file means the scan predates the entry — confirm and close
- the named sample is only the first failure in its bucket; scan the whole repo and triage by root cause
- `badness parse` diagnostics go to **stderr**, and they cascade — triage the earliest error per file
- measure a fix per-file against a baseline binary. Both of my first two attempts at the #75 gate made 4 files *worse* while the headline count improved; only a per-file diff caught it. Now a documented step, with regressions treated as blockers rather than footnotes
- drop entries a fix makes stale — the one way this allowlist can mask a real bug
- report what was *not* fixed and whether the issue can actually close

## Notes

- Rebased onto `main` after #75 merged. That mattered: the branch was cut before the merge, so its `smoke-test.yml` still carried the `source2e.tex` / `ltnews39.tex` entries #75 removed, and merging as-is would have silently re-added them.
- Docs and CI config only — no code change, nothing for the test suite to cover. YAML verified to parse with 53 well-formed `repo|path|type` entries; both added paths confirmed against `git ls-files` in a latex2e checkout.
- I deliberately did **not** allowlist the rest of the latex2e failures. The largest remaining bucket — `.dtx` doc-layer environments (`\begin{macro}`, `oldcomments`, `quote`) failing to pair across macrocode chunks, ~10 files — is a genuine modeling gap, not something unmodelable, and probably wants its own issue so it doesn't get quietly absorbed into the out-of-scope pile later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfuTPZzMY3o3EbUm3s2G2g

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfuTPZzMY3o3EbUm3s2G2g)_