### PR TITLE
fix(parser): stop the lexer hiding braces, guards, and short-verb bars

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -91,6 +91,23 @@ jobs:
         # historical code with a deliberately unbalanced `\vbox{`; oldcomments is a
         # doc `comment`-like environment badness cannot know is opaque. Issue #71.
         latex3/latex2e|base/ltfloat.dtx|format-error
+        # expl3-code.tex rebinds the *structural* catcodes through expl3's own
+        # API: `\char_set_catcode_group_begin:N \^^@` / `_group_end:N` make
+        # `^^@` a brace for a region, so the file's real grouping is invisible
+        # to a `{`/`}`-based reader. Same non-goal as the `\catcode` bootstrap
+        # files above (AGENTS.md decision #1). Issue #71.
+        latex3/latex2e|texmf/tex/latex/l3kernel/expl3-code.tex|format-error
+        # Genuinely broken upstream — one typo each, and badness reads all three
+        # exactly as docstrip and doc.sty do. latex-lab-block.dtx indents a
+        # `%    \begin{macrocode}` frame (column 0 is the docstrip margin rule,
+        # so the frame is commented out and its chunk is typeset as prose);
+        # latex-lab-enumitem.dtx opens a `\changes{` on a `%%` line (the second
+        # `%` comments the line out, stranding the `}` on the next doc line);
+        # latex-lab-new-or-2.dtx comments out an `\end{plugdecl}` as
+        # `% %  \end{plugdecl}`. Issue #71.
+        latex3/latex2e|required/latex-lab/latex-lab-block.dtx|format-error
+        latex3/latex2e|required/latex-lab/latex-lab-enumitem.dtx|format-error
+        latex3/latex2e|required/latex-lab/latex-lab-new-or-2.dtx|format-error
         latex3/latex3|l3kernel/testfiles-backend/support/driver.tex|format-error
         latex3/latex3|texmf/tex/latex/base/nfssfont.tex|format-error
         latex3/latex3|xpackages/xinitials/xinitials-test.tex|format-error

--- a/docs/src/development/parser.md
+++ b/docs/src/development/parser.md
@@ -153,6 +153,16 @@ bodies (a code layer) and after `\left`/`\right` (the `|` is a delimiter). A
 span with no closing character on its line falls back to an ordinary lone
 character.
 
+It is gated off once more after a primitive that grabs the *next token*
+unexpanded (`parser::lexer::is_literal_token_command`:
+`\string`/`\noexpand`/`\meaning`/`\expandafter`/`\show`). `\string|` prints the
+bar—the active character is the token being printed, not a capture opener. The
+doc layer writes that in prose, and capturing there runs the span on to the
+*next* `|` and swallows whatever braces lie between: lthooks.dtx's
+`\meta{first\texttt{\string|}last}\verb|):|` lost the `}` closing `\texttt{`
+and `\meta{`, unnesting the `quote` environment around it (issue #71). This is
+the same family as the `\left`/`\right` gate one paragraph up.
+
 ### Macrocode chunk bodies (`.dtx`)
 
 A frame-lexed `macrocode`/`macrocode*` body is *macro code* whose only
@@ -165,6 +175,20 @@ arguments—the next line's `{` is body code). As with definition bodies,
 Matched pairs still form `GROUP`s, via a per-chunk brace pre-scan
 (`parser::grammar::macrocode_body`), and a `[` attaches as an optional only when
 its `]` closes inside the chunk.
+
+### Docstrip guard lines are content, not blank space (`.dtx`)
+
+A line-leading `%<…>` lexes as a `GUARD` trivia leaf in any layer. For the
+layout rules it *floats* like a `DOC_MARGIN`, so the blank-line test still sees
+`%\n%\n` as a `\par`. But a guard-only line (`%<*dtx>`) is not blank: docstrip
+**deletes** it outright when it strips the file, so the lines around it are
+adjacent, not parted. The shape gates that ask only "did my construct's source
+run out mid-shape?" therefore read
+`TriviaScan::saw_blank_line_outside_guards`—a second blank-line tally that a
+guard resets—rather than the layout one. rotating.dtx is the case: it splits
+`\ProvidesPackage{rotating}`'s `[…date…]` optional across `%<package>` and
+`%<*dtx>`/`%</dtx>` variants, and reading the guard pair as a paragraph break
+bailed out of the `[` mid-argument (issue #71).
 
 ### `^^A` doc comments (`.dtx`)
 
@@ -226,6 +250,17 @@ can never open math or close a group. The escaped single-character form
 symbol—so a `\[`/`\]` there is the character `[`/`]`, not a math delimiter
 (encguide.tex's char-code table pairs `\relax[ … ]` across table rows, issue
 #71). This is the same family as the `\left`/`\right` delimiter isolation.
+
+A bare `{`/`}` is the one exception, and only *inside* a brace group. TeX's
+balanced-text scans—a `\def` body, a macro argument—count brace **tokens**, and
+they run long before `\char` ever would, so at depth > 0 the brace is structure
+and the backtick cannot hide it: ``\def\v{\char`}`` closes at that `}`
+(longtable.dtx), and the ``\ifnum`}=0\fi`` / ``\ifnum`{=\z@\fi`` brace-balance
+idiom keeps its braces structural instead of stranding the group it sits in
+(longtable, amsmath-2018-12-01.sty—issue #71). At depth 0 there is no such scan
+and the constant reading stands: *a close-group character is written*
+``\char`}`` *in running text*. The escaped form ``` `\} ``` is a control symbol,
+never a group delimiter, so it stays data at any depth.
 
 ### Signatures
 

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -171,6 +171,12 @@ struct TriviaScan {
     /// The run before `next` contains a blank line (≥2 `NEWLINE`s: the `\par`
     /// boundary).
     saw_blank_line: bool,
+    /// As [`Self::saw_blank_line`], but a `.dtx` docstrip guard line counts as
+    /// content rather than blank space. Docstrip *deletes* a guard-only line
+    /// when it strips the file, so `%<*dtx>` between two lines does not part
+    /// them — read by the shape gates that only ask whether their construct's
+    /// source ran out mid-shape (issue #71).
+    saw_blank_line_outside_guards: bool,
     /// Start index of the leading own-line `%` comment run immediately preceding
     /// `next` — the maximal blank-line-free suffix, the start of a
     /// leading-comment bind. `None` if that suffix has no own-line comment.
@@ -512,16 +518,21 @@ impl<'t> Parser<'t> {
     /// `DOC_MARGIN`, and `GUARD` float (a `.dtx` margin neither counts as a
     /// newline nor resets the run, so a margin-only line `%\n%\n` still reads as a
     /// blank line via its two `NEWLINE`s); `NEWLINE`s accumulate into the blank-line
-    /// (`≥2`) test; a `COMMENT` is handled per [`CommentMode`]. Does not consume.
+    /// (`≥2`) test; a `COMMENT` is handled per [`CommentMode`]. A `GUARD` floats
+    /// for `saw_blank_line` but breaks the run for
+    /// [`TriviaScan::saw_blank_line_outside_guards`]. Does not consume.
     fn scan_trivia(&self, from: usize, comment_mode: CommentMode) -> TriviaScan {
         let mut i = from;
         let mut newlines = 0;
+        let mut guard_newlines = 0;
         let mut saw_blank_line = false;
+        let mut saw_blank_line_outside_guards = false;
         let mut comment_start = None;
         while let Some(t) = self.tokens.get(i) {
             match t.kind {
                 SyntaxKind::NEWLINE => {
                     newlines += 1;
+                    guard_newlines += 1;
                     if newlines >= 2 {
                         saw_blank_line = true;
                         // A blank line breaks a leading-comment bind: only a
@@ -529,8 +540,19 @@ impl<'t> Parser<'t> {
                         // seen before it.
                         comment_start = None;
                     }
+                    if guard_newlines >= 2 {
+                        saw_blank_line_outside_guards = true;
+                    }
                 }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => {}
+                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN => {}
+                // A docstrip guard floats like a margin for the layout rules
+                // (`saw_blank_line`), but it is *content* on its line — and a
+                // line docstrip deletes outright when it strips the file, so a
+                // guard-only line is not a blank line separating what surrounds
+                // it. Constructs that only need to know whether their source
+                // ran out mid-shape read `saw_blank_line_outside_guards`
+                // instead (issue #71).
+                SyntaxKind::GUARD => guard_newlines = 0,
                 SyntaxKind::COMMENT if comment_mode == CommentMode::Stop => break,
                 // A comment occupies its own line: it is content, not blank space,
                 // so it resets the newline run (without undoing a blank line
@@ -538,6 +560,7 @@ impl<'t> Parser<'t> {
                 // leading-comment bind.
                 SyntaxKind::COMMENT => {
                     newlines = 0;
+                    guard_newlines = 0;
                     if comment_start.is_none() && self.comment_starts_line(i) {
                         comment_start = Some(i);
                     }
@@ -550,6 +573,7 @@ impl<'t> Parser<'t> {
             next: i,
             next_kind: self.tokens.get(i).map(|t| t.kind),
             saw_blank_line,
+            saw_blank_line_outside_guards,
             comment_start,
         }
     }
@@ -579,6 +603,17 @@ impl<'t> Parser<'t> {
     /// True if a paragraph break (blank line) begins at the current position.
     fn at_paragraph_break(&self) -> bool {
         self.scan_trivia(self.pos, CommentMode::Skip).saw_blank_line
+    }
+
+    /// [`Self::at_paragraph_break`], but blind to `.dtx` docstrip guard lines:
+    /// a `%<*dtx>`/`%</dtx>` pair on its own lines is not the blank line it
+    /// looks like, because docstrip deletes those lines outright. Used by the
+    /// bail-out anchors of constructs that legitimately span a guarded block —
+    /// `\ProvidesPackage{…}` and its `[…date…]` optional, split across
+    /// `%<package>`/`%<*dtx>` variants (rotating.dtx, issue #71).
+    fn at_paragraph_break_outside_guards(&self) -> bool {
+        self.scan_trivia(self.pos, CommentMode::Skip)
+            .saw_blank_line_outside_guards
     }
 
     /// True if the comment at `pos` starts its own line: scanning back over
@@ -1120,7 +1155,7 @@ impl<'t> Parser<'t> {
                 _ => {
                     // The macrocode frame terminator is absolute: an optional
                     // still open there is abandoned, never consumes the frame.
-                    if self.at_paragraph_break()
+                    if self.at_paragraph_break_outside_guards()
                         || self.macrocode_end.is_some_and(|end| self.pos >= end)
                     {
                         self.error_at(opener, "unclosed `[`");

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -237,6 +237,19 @@ fn is_definition_keyword(text: &str) -> bool {
 /// The number-*producing* primitives (`\number`/`\the`/`\romannumeral`) and the
 /// numeric conditionals (`\ifnum`/`\ifodd`/`\ifdim`) are included alongside the
 /// codetables because their operand is just as routinely a backtick constant.
+/// Whether `text` (a `CONTROL_WORD`, leading `\` included) is a TeX primitive
+/// that grabs the *next token* without expanding it, so a following character
+/// keeps its literal shape. Only the short-verb capture reads this: an active
+/// `|` after `\string` is the token being printed, not a `\verb`-style opener
+/// (`\meta{first\texttt{\string|}last}`, lthooks.dtx). A closed curated set,
+/// read from the static keyword alone — no macro meaning.
+fn is_literal_token_command(text: &str) -> bool {
+    matches!(
+        text,
+        "\\string" | "\\noexpand" | "\\meaning" | "\\expandafter" | "\\show"
+    )
+}
+
 fn is_char_constant_command(text: &str) -> bool {
     matches!(
         text,
@@ -300,7 +313,7 @@ pub fn lex(input: &str) -> Vec<Token> {
 /// [`Package`](LatexFlavor::Package) flavor starts with `@` already a letter) and
 /// whether to run the `.dtx` docstrip mode.
 pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
-    let mut out = Vec::new();
+    let mut out: Vec<Token> = Vec::new();
     let mut pos = 0;
     let mut at_letter = config.flavor.letter_mode_start(); // `\makeatletter` state
     // `\ExplSyntaxOn` state: while true, `_` and `:` are catcode-11 letters, so
@@ -355,8 +368,27 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
     // prose (issue #60), so without this the hidden `$`/`{` cascade into
     // unclosed-math and unclosed-group diagnostics.
     let mut pending_char_constant = false;
+    // True right after a primitive that consumes the *next token* unexpanded
+    // ([`is_literal_token_command`]), where a short-verb character is that
+    // token rather than a capture opener (`\string|`, lthooks.dtx, issue #71).
+    let mut pending_literal_token = false;
+    // Number of brace groups open at the cursor, counted over every token
+    // emitted so far (helpers push braces too, so `out` is the one place that
+    // sees them all). Read by the char-constant branch: inside a group TeX has
+    // already claimed a `{`/`}` as balanced-text structure, so a backtick there
+    // cannot hide it. Saturating, so an unbalanced file never underflows.
+    let mut brace_depth = 0usize;
+    let mut brace_counted = 0usize;
     while pos < input.len() {
         let rest = &input[pos..];
+        while brace_counted < out.len() {
+            match out[brace_counted].kind {
+                SyntaxKind::L_BRACE => brace_depth += 1,
+                SyntaxKind::R_BRACE => brace_depth = brace_depth.saturating_sub(1),
+                _ => {}
+            }
+            brace_counted += 1;
+        }
 
         // `.dtx` `macrocode` frame line. A `%␣*\begin{macrocode}` line opens a code
         // region; its `%␣*\end{macrocode}` terminator closes it. Both lex as a
@@ -380,6 +412,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
             pos += consumed;
             at_line_start = false;
             pending_delim = false;
+            pending_literal_token = false;
             pending_def = false;
             continue;
         }
@@ -439,6 +472,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
         if let Some(consumed) = lex_verbatim_environment(rest, ctx, &mut out) {
             pos += consumed;
             pending_delim = false;
+            pending_literal_token = false;
             pending_def = false;
             at_line_start = false;
             continue;
@@ -451,6 +485,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
         if !in_macrocode && let Some(consumed) = lex_verbatim_arg_environment(rest, &mut out) {
             pos += consumed;
             pending_delim = false;
+            pending_literal_token = false;
             pending_def = false;
             at_line_start = false;
             continue;
@@ -467,6 +502,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
         {
             pos += consumed;
             pending_delim = false;
+            pending_literal_token = false;
             at_line_start = false;
             continue;
         }
@@ -477,10 +513,15 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
         // ordinary catcode-12 character) and after `\left`/`\right` (whose next
         // character is a delimiter, `\left|x\right|`). With no closing delimiter
         // on the line, fall through: the word-run truncation below still emits
-        // the lone character as its own token.
+        // the lone character as its own token. Also gated off after a primitive
+        // that takes the next token unexpanded ([`is_literal_token_command`]):
+        // `\string|` prints the bar, it does not open a capture that would run
+        // to the next `|` and swallow the intervening braces (lthooks.dtx's
+        // `\meta{first\texttt{\string|}last}\verb|):|`, issue #71).
         if !short_verbs.is_empty()
             && !in_macrocode
             && !pending_delim
+            && !pending_literal_token
             && let Some(c) = rest.chars().next()
             && short_verbs.contains(&c)
             && let Some(len) = delimited_len(rest)
@@ -503,10 +544,22 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
         // way, backtick plus the whole control symbol: a `\[`/`\]` there is the
         // *character* `[`/`]`, not a math delimiter (encguide.tex's char-code
         // table, issue #71).
+        //
+        // A *bare* `{`/`}` is the exception, and only at brace depth 0. Inside a
+        // group the brace has already been claimed as structure by whichever
+        // balanced-text scan opened it — a `\def` body or a macro argument, both
+        // of which count brace *tokens* long before `\char` ever runs — so the
+        // `}` in `` \def\v{\char`} `` (longtable.dtx) and the `` \ifnum`}=0\fi ``
+        // brace-balance idiom (longtable/amsmath) closes its group and is not
+        // data. At depth 0 there is no such scan and the constant reading stands
+        // (`a close-group character is written \char`} in running text`). The
+        // *escaped* form `` `\} `` is unaffected: a control symbol is never a
+        // group delimiter, so it stays data at any depth (issue #71).
         if pending_char_constant
             && let Some(after) = rest.strip_prefix('`')
             && let Some(c) = after.chars().next()
             && !matches!(c, '\n' | '\r')
+            && !(brace_depth > 0 && matches!(c, '{' | '}'))
             && let Some(len) = if c == '\\' {
                 // `` `\X ``: backtick, backslash, and one escaped character; a
                 // bare `` `\ `` at line end has no character and falls through.
@@ -527,6 +580,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
             at_line_start = false;
             pending_char_constant = false;
             pending_delim = false;
+            pending_literal_token = false;
             pending_def = false;
             continue;
         }
@@ -548,6 +602,7 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
             pos += len;
             at_line_start = false;
             pending_delim = false;
+            pending_literal_token = false;
             pending_def = false;
             continue;
         }
@@ -614,6 +669,12 @@ pub fn lex_with(input: &str, ctx: &VerbCtx, config: LexConfig) -> Vec<Token> {
             // Trivia is skipped before the delimiter, so the mode persists.
             SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE => pending_delim,
             SyntaxKind::CONTROL_WORD if text == "\\left" || text == "\\right" => true,
+            _ => false,
+        };
+        pending_literal_token = match kind {
+            // TeX skips spaces before the token it is about to grab.
+            SyntaxKind::WHITESPACE => pending_literal_token,
+            SyntaxKind::CONTROL_WORD if is_literal_token_command(text) => true,
             _ => false,
         };
         pending_char_constant = match kind {

--- a/tests/corpus/dtx_guard_spanning_optional.dtx
+++ b/tests/corpus/dtx_guard_spanning_optional.dtx
@@ -1,0 +1,13 @@
+%    \begin{macrocode}
+\NeedsTeXFormat{LaTeX2e}
+%<*dtx>
+\ProvidesFile{rotating.dtx}%
+%</dtx>
+%<package>\ProvidesPackage{rotating}%
+    [2026-05-17 v2.16e
+%<package>  rotated objects in LaTeX%
+%<*dtx>
+            rotating package source file%
+%</dtx>
+        ]
+%    \end{macrocode}

--- a/tests/corpus/dtx_short_verb_string.dtx
+++ b/tests/corpus/dtx_short_verb_string.dtx
@@ -1,0 +1,9 @@
+% \begin{quote}
+%   \quad\verb|Document-level (top-level) code (executed |%^^A
+%              \meta{first\texttt{\string|}last}\verb|):|\\
+%   \quad\verb|    -> |\meta{\texttt{top-level} code}
+% \end{quote}
+%
+%    \begin{macrocode}
+\def\ExampleHook{top-level}
+%    \end{macrocode}

--- a/tests/dtx.rs
+++ b/tests/dtx.rs
@@ -662,3 +662,40 @@ fn doc_margin_envs_still_pair_inside_a_spanning_expl_region() {
     // Two macrocode chunks plus the doc-layer `macro` environment.
     assert_eq!(count(&root, SyntaxKind::ENVIRONMENT), 3);
 }
+
+#[test]
+fn guard_only_line_does_not_part_an_optional_argument() {
+    // A `%<*dtx>`/`%</dtx>` block-guard line is content, and one docstrip
+    // *deletes* when it strips the file — so it is not the blank line its bare
+    // `NEWLINE GUARD NEWLINE` shape resembles. rotating.dtx splits
+    // `\ProvidesPackage{rotating}`'s `[…date…]` optional across such guards;
+    // reading them as a paragraph break bailed out of the `[` mid-argument
+    // (issue #71).
+    let (_root, errors) = parse_dtx_with_errors(
+        "%    \\begin{macrocode}\n\
+         \\ProvidesPackage{rotating}%\n    \
+         [2026-05-17 v2.16e\n\
+         %<*dtx>\n            \
+         rotating package source file%\n\
+         %</dtx>\n        \
+         ]\n\
+         %    \\end{macrocode}\n",
+    );
+    assert_eq!(errors, 0);
+}
+
+#[test]
+fn short_verb_char_after_string_is_literal() {
+    // `\string|` prints the bar: `\string` takes the next token unexpanded, so
+    // the active short-verb `|` is data, not a capture opener. Capturing there
+    // ran the span to the *next* `|` and swallowed the intervening braces,
+    // stranding `\meta{`/`\texttt{` and unnesting the doc environment around it
+    // (lthooks.dtx, issue #71).
+    let (root, errors) = parse_dtx_with_errors(
+        "% \\begin{quote}\n\
+         %   \\verb|x |\\meta{a\\texttt{\\string|}b}\\verb|y|\n\
+         % \\end{quote}\n",
+    );
+    assert_eq!(errors, 0);
+    assert_eq!(count(&root, SyntaxKind::ENVIRONMENT), 1);
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1003,9 +1003,24 @@ fn spaced_name_group_still_reads_as_an_environment() {
 fn char_constant_backtick_keeps_the_next_character_plain() {
     // TeX char-constant notation (smoke-test issue #60): after `\char`/
     // `\catcode`-family primitives, a backtick makes the next character data —
-    // `\char`$` must not open math and `\char`}` must not close a group. The
-    // backtick and its character lex as one plain `WORD` token.
-    insta::assert_snapshot!(tree("\\item[\\char`$ or z] and {\\char`} too}"));
+    // `\char`$` must not open math, and in running text `\char`}` is the
+    // close-group *character*, not a group closer. The backtick and its
+    // character lex as one plain `WORD` token.
+    insta::assert_snapshot!(tree("\\item[\\char`$ or z] and \\char`} too"));
+}
+
+#[test]
+fn char_constant_backtick_never_hides_a_brace_inside_a_group() {
+    // Inside a group the brace wins: whichever balanced-text scan opened it — a
+    // `\def` body here — counts brace *tokens* long before `\char` could run,
+    // so `` \def\v{\char`} `` closes at that `}` (longtable.dtx), and the
+    // `` \ifnum`}=0\fi `` / `` \ifnum`{=\z@\fi `` balance idiom keeps its braces
+    // structural instead of stranding the enclosing group (issue #71). The
+    // escaped form `` `\} `` is a control symbol, never a delimiter, so it
+    // stays data at any depth.
+    insta::assert_snapshot!(tree(
+        "\\def\\v{\\char`}\n\\def\\w{\\noalign{\\ifnum`}=0\\fi x}\n\\def\\z{\\char`\\}}"
+    ));
 }
 
 #[test]

--- a/tests/snapshots/parser__char_constant_backtick_keeps_the_next_character_plain.snap
+++ b/tests/snapshots/parser__char_constant_backtick_keeps_the_next_character_plain.snap
@@ -1,9 +1,9 @@
 ---
 source: tests/parser.rs
-expression: "tree(\"\\\\item[\\\\char`$ or z] and {\\\\char`} too}\")"
+expression: "tree(\"\\\\item[\\\\char`$ or z] and \\\\char`} too\")"
 ---
-ROOT@0..37
-  PARAGRAPH@0..37
+ROOT@0..35
+  PARAGRAPH@0..35
     COMMAND@0..19
       CONTROL_WORD@0..5 "\\item"
       OPTIONAL@5..19
@@ -19,11 +19,8 @@ ROOT@0..37
     WHITESPACE@19..20 " "
     WORD@20..23 "and"
     WHITESPACE@23..24 " "
-    GROUP@24..37
-      L_BRACE@24..25 "{"
-      COMMAND@25..30
-        CONTROL_WORD@25..30 "\\char"
-      WORD@30..32 "`}"
-      WHITESPACE@32..33 " "
-      WORD@33..36 "too"
-      R_BRACE@36..37 "}"
+    COMMAND@24..29
+      CONTROL_WORD@24..29 "\\char"
+    WORD@29..31 "`}"
+    WHITESPACE@31..32 " "
+    WORD@32..35 "too"

--- a/tests/snapshots/parser__char_constant_backtick_never_hides_a_brace_inside_a_group.snap
+++ b/tests/snapshots/parser__char_constant_backtick_never_hides_a_brace_inside_a_group.snap
@@ -1,0 +1,48 @@
+---
+source: tests/parser.rs
+expression: "tree(\"\\\\def\\\\v{\\\\char`}\\n\\\\def\\\\w{\\\\noalign{\\\\ifnum`}=0\\\\fi x}\\n\\\\def\\\\z{\\\\char`\\\\}}\")"
+---
+ROOT@0..64
+  PARAGRAPH@0..64
+    COMMAND@0..4
+      CONTROL_WORD@0..4 "\\def"
+    COMMAND@4..14
+      CONTROL_WORD@4..6 "\\v"
+      GROUP@6..14
+        L_BRACE@6..7 "{"
+        COMMAND@7..12
+          CONTROL_WORD@7..12 "\\char"
+        WORD@12..13 "`"
+        R_BRACE@13..14 "}"
+    NEWLINE@14..15 "\n"
+    COMMAND@15..19
+      CONTROL_WORD@15..19 "\\def"
+    COMMAND@19..47
+      CONTROL_WORD@19..21 "\\w"
+      GROUP@21..47
+        L_BRACE@21..22 "{"
+        COMMAND@22..39
+          CONTROL_WORD@22..30 "\\noalign"
+          GROUP@30..39
+            L_BRACE@30..31 "{"
+            COMMAND@31..37
+              CONTROL_WORD@31..37 "\\ifnum"
+            WORD@37..38 "`"
+            R_BRACE@38..39 "}"
+        WORD@39..41 "=0"
+        COMMAND@41..44
+          CONTROL_WORD@41..44 "\\fi"
+        WHITESPACE@44..45 " "
+        WORD@45..46 "x"
+        R_BRACE@46..47 "}"
+    NEWLINE@47..48 "\n"
+    COMMAND@48..52
+      CONTROL_WORD@48..52 "\\def"
+    COMMAND@52..64
+      CONTROL_WORD@52..54 "\\z"
+      GROUP@54..64
+        L_BRACE@54..55 "{"
+        COMMAND@55..60
+          CONTROL_WORD@55..60 "\\char"
+        WORD@60..63 "`\\}"
+        R_BRACE@63..64 "}"


### PR DESCRIPTION
Three shape gates in the `.dtx`/package layer, all one bug apiece in what the
lexer is allowed to swallow. Together they take latex3/latex2e's debug-format
failures from 26 to 21, fully fixing five files with no file regressing and no
new idempotency or losslessness failures; the other nine scanned repositories
are byte-identical before and after.

Char-constant isolation now stops at a bare brace *inside* a group. TeX's
balanced-text scans — a `\def` body, a macro argument — count brace **tokens**,
and they run long before `\char` ever would, so at depth > 0 the brace is
structure and the backtick cannot hide it: `\def\v{\char`}` closes at that `}`
(longtable.dtx), and the `\ifnum`}=0\fi` / `\ifnum`{=\z@\fi` brace-balance
idiom keeps its braces structural instead of stranding the group it sits in
(longtable-2020-01-07.sty, amsmath-2018-12-01.sty). At depth 0 there is no such
scan and the issue #60 reading stands: a close-group character is written
`\char`} in running text. The escaped form is a control symbol, never a
delimiter, so it stays data at any depth.

A docstrip guard line is content, not blank space. `%<*dtx>` on its own line
lexes as `NEWLINE GUARD NEWLINE`, which read as a blank line — but docstrip
*deletes* that line when it strips the file, so the lines around it are
adjacent. The shape gates that only ask whether their construct's source ran
out mid-shape now read a second blank-line tally a guard resets, leaving the
layout rules' `\par` test untouched. rotating.dtx splits `\ProvidesPackage`'s
`[…date…]` optional across `%<package>` and `%<*dtx>` variants, and the false
paragraph break bailed out of the `[` mid-argument.

A short-verb character after a primitive that grabs the next token unexpanded
is that token, not a capture opener. `\string|` prints the bar; capturing there
ran the span on to the next `|` and swallowed the braces between, so
lthooks.dtx's `\meta{first\texttt{\string|}last}\verb|):|` lost the `}` closing
`\texttt{` and `\meta{` and unnested the `quote` around it.

Refs #71

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GeePSEX7jqzocy2iFGBrnY