### PR TITLE
chore(release): v0.14.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "4fb98f7d764030cc7d1af8d875eb35b914ad10d8",
+  "baseline-sha": "25e54713cafb058bcfccd79b9eef5001726a5910",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "badness-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "badness-code-v0.14.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "badness-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "badness-code-v0.14.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/badness/compare/v0.13.0...v0.14.0) (2026-08-06)
+
+### Features
+- **cli:** diff changed files in `format --check` ([`eed1537`](https://github.com/jolars/badness/commit/eed1537d15fd467b09b89e0750a5decbb42d1cf7))
+- **semantic:** curate filecontents and ltxdockit verbatim envs ([`d805548`](https://github.com/jolars/badness/commit/d8055483cc4716eb89327ea3c9a85f7f45cbe212)), closes [#98](https://github.com/jolars/badness/issues/98)
+- **formatter:** respace flush expl3 argument braces ([`c44125c`](https://github.com/jolars/badness/commit/c44125cf40212a5ca518f0f9beda295de03d7069))
+- **formatter:** add trivia-perturbation invariance oracle (#103) ([`f22d668`](https://github.com/jolars/badness/commit/f22d668c6c95d323b0cc3ecb110db811bd0f23ba))
+- **packaging:** publish badness-bin to the AUR on release ([`82a64c2`](https://github.com/jolars/badness/commit/82a64c2284fe71a4155b481d22507901abffda1d))
+- **lint:** add `--output json` machine-readable findings ([`92b04bd`](https://github.com/jolars/badness/commit/92b04bd48c35587e4157438e98960ab08171772b))
+- **formatter:** explode expl3 conditional branches (R4) ([`bebdbde`](https://github.com/jolars/badness/commit/bebdbdecce2a493135c7da826259a322cfe097cb))
+- **parser:** recognize package-defined verbatim envs ([`696f109`](https://github.com/jolars/badness/commit/696f109074c612fad2998ab194ece275c0b7713b))
+- **build:** bundle man pages and completion in tarballs ([`8268c88`](https://github.com/jolars/badness/commit/8268c885ce8811dd33a533cd8f8085b998bdd1d2))
+
+### Bug Fixes
+- **formatter:** render expl3 conditionals all-or-nothing ([`c8b3aef`](https://github.com/jolars/badness/commit/c8b3aef1ac0b68671b5136233273fb15edcc384b))
+- **formatter:** keep annotated expl3 branches on the exploded path ([`ac07506`](https://github.com/jolars/badness/commit/ac0750624e01506172d0a3192b0df35186f9928f)), refs [#101](https://github.com/jolars/badness/issues/101)
+- **formatter:** drop expl3 sibling break coupling ([`836ed83`](https://github.com/jolars/badness/commit/836ed83b6b3ea4914dd4580457ea5ebd73299afb)), closes [#101](https://github.com/jolars/badness/issues/101)
+- **packaging:** tolerate pre-0.14 release tarballs in PKGBUILD ([`750493b`](https://github.com/jolars/badness/commit/750493b97a142ff40b35ce250680c5d2d716e1aa))
+- **installer:** detect musl/libc in installation script ([`eb195a1`](https://github.com/jolars/badness/commit/eb195a1904bbf0a7a3a8d2f83308a3539b748ffc))
+- **formatter:** pin forced expl3 block body to break mode ([`349ccdd`](https://github.com/jolars/badness/commit/349ccdd26f1e269703bee96feaaec41a16d0fff2))
+- **formatter:** stabilize trailing expl3 hang group ([`72a6d35`](https://github.com/jolars/badness/commit/72a6d3585bd3e4310cd26aeef347740c933c0979)), closes [#96](https://github.com/jolars/badness/issues/96)
+- **npm:** fall back to musl when glibc build fails ([`bd1891e`](https://github.com/jolars/badness/commit/bd1891e0961bc36c0c6f088d5f61b33b0db0af47))
+- **formatter:** stabilize trailing expl3 conditional ([`b5ed902`](https://github.com/jolars/badness/commit/b5ed902de89c7619c55d7a143784e21383500863)), refs [#96](https://github.com/jolars/badness/issues/96)
+- **parser:** pair \left/\right inside macro code ([`20a59ef`](https://github.com/jolars/badness/commit/20a59eff44e3b6b4e4a0013291a99d7b2ae1221f)), closes [#95](https://github.com/jolars/badness/issues/95)
+- **parser:** bound math bracket gate at dollar closer ([`703f5f5`](https://github.com/jolars/badness/commit/703f5f569acd01a92f57b8a5006c159401fe4249)), closes [#99](https://github.com/jolars/badness/issues/99)
+- **formatter:** keep expl3 parameter runs tight ([`47d6277`](https://github.com/jolars/badness/commit/47d62775abcc2620329db9508a1f8a52bdeda55b)), exception [#1](https://github.com/jolars/badness/issues/1) and [#2](https://github.com/jolars/badness/issues/2)
+- **formatter:** sticky-break fill for expl3 statements ([`107ecb0`](https://github.com/jolars/badness/commit/107ecb0e97525f5f10ed520599ca2a5e4fec882c)), closes [#94](https://github.com/jolars/badness/issues/94)
+- **linter:** stop TikZ/pgf false positives ([`aca172f`](https://github.com/jolars/badness/commit/aca172f3bc782bf98dc6836a4f21c80711e38a6d))
+- **linter:** drop "Part", gate hard-coded-reference item labels ([`274c124`](https://github.com/jolars/badness/commit/274c1243d94cf451bef6f03317ecf1c60eb61277))
+- **linter:** gate space-before-command on trailing break ([`2f66cae`](https://github.com/jolars/badness/commit/2f66cae638337bc56f21ca7838e6884586720173))
+- **linter:** skip hex constants, font maps in straight-quotes ([`2fb9ee3`](https://github.com/jolars/badness/commit/2fb9ee31f7c6709616526a2c1bafb03eec225afa))
+- **linter:** skip redefined commands in deprecated/primitive ([`0490f16`](https://github.com/jolars/badness/commit/0490f16c3a708d6cdc0b24c93ceb82fb3e5358ad))
+- **linter:** skip starred headings in sectioning-level-jump ([`befe30e`](https://github.com/jolars/badness/commit/befe30e44cf7e6d6528333a164dc56988365d612))
+- **parser:** parse array and tikzcd bodies as math ([`9db4e8f`](https://github.com/jolars/badness/commit/9db4e8fc3f492303479ee572d4e50aba88f85622))
+
 ## [0.13.0](https://github.com/jolars/badness/compare/v0.12.0...v0.13.0) (2026-08-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -85,14 +85,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "badness"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -234,9 +228,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+checksum = "64f383fe92a826d3b1a3c18e0cb791bef22948931b4909f6781adea466ede5e8"
 dependencies = [
  "clap",
  "roff",
@@ -426,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -471,9 +465,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -509,12 +503,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -560,9 +551,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -653,15 +644,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "nom"
@@ -867,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -942,9 +924,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14fdadbf856222e731756d7fdbdf193a7abf8fdab009bb45f48671a42719a84"
+checksum = "cf0e374215cd2db2b5c75d7b3a99cb0cc052c0595335dfdefc03d4eb08f4aa81"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -968,19 +950,19 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d7dc08ba69b9aedfa61dfc4d65548ae42c0d8b90bbd62cd121776920841bcf"
+checksum = "85f4b7d4405540bbd6d4ffa52d4322d983f3781954d3073067ac1bdb028459b3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5c48c5a4a53a6e2be9762f56566f1325d4394c011c00b3ea86ba2d13411e71"
+checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/badness/compare/badness-code-v0.13.0...badness-code-v0.14.0) (2026-08-06)
+
+### Dependencies
+- updated badness to v0.14.0
+
 ## [0.13.0](https://github.com/jolars/badness/compare/badness-code-v0.12.0...badness-code-v0.13.0) (2026-08-01)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.13.0",
-    "@badness/linux-arm64-gnu": "0.13.0",
-    "@badness/linux-x64-musl": "0.13.0",
-    "@badness/linux-arm64-musl": "0.13.0",
-    "@badness/darwin-x64": "0.13.0",
-    "@badness/darwin-arm64": "0.13.0",
-    "@badness/win32-x64": "0.13.0",
-    "@badness/win32-arm64": "0.13.0"
+    "@badness/linux-x64-gnu": "0.14.0",
+    "@badness/linux-arm64-gnu": "0.14.0",
+    "@badness/linux-x64-musl": "0.14.0",
+    "@badness/linux-arm64-musl": "0.14.0",
+    "@badness/darwin-x64": "0.14.0",
+    "@badness/darwin-arm64": "0.14.0",
+    "@badness/win32-x64": "0.14.0",
+    "@badness/win32-arm64": "0.14.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.14.0](https://github.com/jolars/badness/compare/v0.13.0...v0.14.0) (2026-08-06)

### Features
- **cli:** diff changed files in `format --check` ([`eed1537`](https://github.com/jolars/badness/commit/eed1537d15fd467b09b89e0750a5decbb42d1cf7))
- **semantic:** curate filecontents and ltxdockit verbatim envs ([`d805548`](https://github.com/jolars/badness/commit/d8055483cc4716eb89327ea3c9a85f7f45cbe212)), closes [#98](https://github.com/jolars/badness/issues/98)
- **formatter:** respace flush expl3 argument braces ([`c44125c`](https://github.com/jolars/badness/commit/c44125cf40212a5ca518f0f9beda295de03d7069))
- **formatter:** add trivia-perturbation invariance oracle (#103) ([`f22d668`](https://github.com/jolars/badness/commit/f22d668c6c95d323b0cc3ecb110db811bd0f23ba))
- **packaging:** publish badness-bin to the AUR on release ([`82a64c2`](https://github.com/jolars/badness/commit/82a64c2284fe71a4155b481d22507901abffda1d))
- **lint:** add `--output json` machine-readable findings ([`92b04bd`](https://github.com/jolars/badness/commit/92b04bd48c35587e4157438e98960ab08171772b))
- **formatter:** explode expl3 conditional branches (R4) ([`bebdbde`](https://github.com/jolars/badness/commit/bebdbdecce2a493135c7da826259a322cfe097cb))
- **parser:** recognize package-defined verbatim envs ([`696f109`](https://github.com/jolars/badness/commit/696f109074c612fad2998ab194ece275c0b7713b))
- **build:** bundle man pages and completion in tarballs ([`8268c88`](https://github.com/jolars/badness/commit/8268c885ce8811dd33a533cd8f8085b998bdd1d2))

### Bug Fixes
- **formatter:** render expl3 conditionals all-or-nothing ([`c8b3aef`](https://github.com/jolars/badness/commit/c8b3aef1ac0b68671b5136233273fb15edcc384b))
- **formatter:** keep annotated expl3 branches on the exploded path ([`ac07506`](https://github.com/jolars/badness/commit/ac0750624e01506172d0a3192b0df35186f9928f)), refs [#101](https://github.com/jolars/badness/issues/101)
- **formatter:** drop expl3 sibling break coupling ([`836ed83`](https://github.com/jolars/badness/commit/836ed83b6b3ea4914dd4580457ea5ebd73299afb)), closes [#101](https://github.com/jolars/badness/issues/101)
- **packaging:** tolerate pre-0.14 release tarballs in PKGBUILD ([`750493b`](https://github.com/jolars/badness/commit/750493b97a142ff40b35ce250680c5d2d716e1aa))
- **installer:** detect musl/libc in installation script ([`eb195a1`](https://github.com/jolars/badness/commit/eb195a1904bbf0a7a3a8d2f83308a3539b748ffc))
- **formatter:** pin forced expl3 block body to break mode ([`349ccdd`](https://github.com/jolars/badness/commit/349ccdd26f1e269703bee96feaaec41a16d0fff2))
- **formatter:** stabilize trailing expl3 hang group ([`72a6d35`](https://github.com/jolars/badness/commit/72a6d3585bd3e4310cd26aeef347740c933c0979)), closes [#96](https://github.com/jolars/badness/issues/96)
- **npm:** fall back to musl when glibc build fails ([`bd1891e`](https://github.com/jolars/badness/commit/bd1891e0961bc36c0c6f088d5f61b33b0db0af47))
- **formatter:** stabilize trailing expl3 conditional ([`b5ed902`](https://github.com/jolars/badness/commit/b5ed902de89c7619c55d7a143784e21383500863)), refs [#96](https://github.com/jolars/badness/issues/96)
- **parser:** pair \left/\right inside macro code ([`20a59ef`](https://github.com/jolars/badness/commit/20a59eff44e3b6b4e4a0013291a99d7b2ae1221f)), closes [#95](https://github.com/jolars/badness/issues/95)
- **parser:** bound math bracket gate at dollar closer ([`703f5f5`](https://github.com/jolars/badness/commit/703f5f569acd01a92f57b8a5006c159401fe4249)), closes [#99](https://github.com/jolars/badness/issues/99)
- **formatter:** keep expl3 parameter runs tight ([`47d6277`](https://github.com/jolars/badness/commit/47d62775abcc2620329db9508a1f8a52bdeda55b)), exception [#1](https://github.com/jolars/badness/issues/1) and [#2](https://github.com/jolars/badness/issues/2)
- **formatter:** sticky-break fill for expl3 statements ([`107ecb0`](https://github.com/jolars/badness/commit/107ecb0e97525f5f10ed520599ca2a5e4fec882c)), closes [#94](https://github.com/jolars/badness/issues/94)
- **linter:** stop TikZ/pgf false positives ([`aca172f`](https://github.com/jolars/badness/commit/aca172f3bc782bf98dc6836a4f21c80711e38a6d))
- **linter:** drop "Part", gate hard-coded-reference item labels ([`274c124`](https://github.com/jolars/badness/commit/274c1243d94cf451bef6f03317ecf1c60eb61277))
- **linter:** gate space-before-command on trailing break ([`2f66cae`](https://github.com/jolars/badness/commit/2f66cae638337bc56f21ca7838e6884586720173))
- **linter:** skip hex constants, font maps in straight-quotes ([`2fb9ee3`](https://github.com/jolars/badness/commit/2fb9ee31f7c6709616526a2c1bafb03eec225afa))
- **linter:** skip redefined commands in deprecated/primitive ([`0490f16`](https://github.com/jolars/badness/commit/0490f16c3a708d6cdc0b24c93ceb82fb3e5358ad))
- **linter:** skip starred headings in sectioning-level-jump ([`befe30e`](https://github.com/jolars/badness/commit/befe30e44cf7e6d6528333a164dc56988365d612))
- **parser:** parse array and tikzcd bodies as math ([`9db4e8f`](https://github.com/jolars/badness/commit/9db4e8fc3f492303479ee572d4e50aba88f85622))

## [editors/code: 0.14.0](https://github.com/jolars/badness/compare/badness-code-v0.13.0...badness-code-v0.14.0) (2026-08-06)

### Dependencies
- updated badness to v0.14.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).