### PR TITLE
chore(release): v0.15.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "25e54713cafb058bcfccd79b9eef5001726a5910",
+  "baseline-sha": "db63ddbf49cf58bc5534106894131e9a2686bec1",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
+    },
+    {
+      "path": "crates/badness-formatter",
+      "version": "0.2.0",
+      "tag": "badness-formatter-v0.2.0"
+    },
+    {
+      "path": "crates/badness-parser",
+      "version": "0.1.1",
+      "tag": "badness-parser-v0.1.1"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "badness-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "badness-code-v0.15.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
+    },
+    {
+      "path": "crates/badness-formatter",
+      "version": "0.2.0",
+      "tag": "badness-formatter-v0.2.0"
+    },
+    {
+      "path": "crates/badness-parser",
+      "version": "0.1.1",
+      "tag": "badness-parser-v0.1.1"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "badness-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "badness-code-v0.15.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/badness/compare/v0.14.0...v0.15.0) (2026-08-07)
+
+### Features
+- **formatter:** default every file kind to reflow ([`ba9f2f9`](https://github.com/jolars/badness/commit/ba9f2f9dde4d8f50e073f53b6fd0b643787c0539))
+- **formatter:** add a line-ending style ([`373a16c`](https://github.com/jolars/badness/commit/373a16c5012b53d4d8f500e19f396e0c66728aa2))
+- **wasm:** add `badness-wasm` playground shim crate ([`6486890`](https://github.com/jolars/badness/commit/648689051f65d7729a27821605ea1473e967be6b))
+
+### Bug Fixes
+- **formatter:** hug detonating atoms in fallback fills ([`db63ddb`](https://github.com/jolars/badness/commit/db63ddbf49cf58bc5534106894131e9a2686bec1))
+- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
+- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
+- **linter:** skip parameter-template keys in key scans ([`928aa4a`](https://github.com/jolars/badness/commit/928aa4ace51aa193430a1445f9d7d6afacff8f2e)), closes [#104](https://github.com/jolars/badness/issues/104)
+- **formatter:** keep fitting math segments flat ([`903ec3e`](https://github.com/jolars/badness/commit/903ec3e240023ea1f68af3b8a1a78d4151b3e97d))
+
+### Dependencies
+- updated crates/badness-formatter to v0.2.0
+- updated crates/badness-parser to v0.1.1
+
 ## [0.14.0](https://github.com/jolars/badness/compare/v0.13.0...v0.14.0) (2026-08-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "badness"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "insta",
  "parser",
@@ -217,9 +217,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -266,9 +266,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f383fe92a826d3b1a3c18e0cb791bef22948931b4909f6781adea466ede5e8"
+checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
 dependencies = [
  "clap",
  "roff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"
@@ -41,8 +41,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.1.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.1.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.2.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.1.1" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/badness/compare/badness-formatter-v0.1.0...badness-formatter-v0.2.0) (2026-08-07)
+
+### Features
+- **formatter:** default every file kind to reflow ([`ba9f2f9`](https://github.com/jolars/badness/commit/ba9f2f9dde4d8f50e073f53b6fd0b643787c0539))
+- **formatter:** add a line-ending style ([`373a16c`](https://github.com/jolars/badness/commit/373a16c5012b53d4d8f500e19f396e0c66728aa2))
+
+### Bug Fixes
+- **formatter:** hug detonating atoms in fallback fills ([`db63ddb`](https://github.com/jolars/badness/commit/db63ddbf49cf58bc5534106894131e9a2686bec1))
+- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
+- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
+- **formatter:** keep fitting math segments flat ([`903ec3e`](https://github.com/jolars/badness/commit/903ec3e240023ea1f68af3b8a1a78d4151b3e97d))
+
+### Dependencies
+- updated crates/badness-parser to v0.1.1

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for LaTeX and BibTeX"
@@ -14,7 +14,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.1.0" }
+badness-parser = { path = "../badness-parser", version = "0.1.1" }
 rowan = "0.16.1"
 
 [dev-dependencies]

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1](https://github.com/jolars/badness/compare/badness-parser-v0.1.0...badness-parser-v0.1.1) (2026-08-07)
+
+### Bug Fixes
+- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
+- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
+- **linter:** skip parameter-template keys in key scans ([`928aa4a`](https://github.com/jolars/badness/commit/928aa4ace51aa193430a1445f9d7d6afacff8f2e)), closes [#104](https://github.com/jolars/badness/issues/104)

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, semantic model, and command-signature database for LaTeX and BibTeX"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/badness/compare/badness-code-v0.14.0...badness-code-v0.15.0) (2026-08-07)
+
+### Dependencies
+- updated badness to v0.15.0
+
 ## [0.14.0](https://github.com/jolars/badness/compare/badness-code-v0.13.0...badness-code-v0.14.0) (2026-08-06)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.14.0",
-    "@badness/linux-arm64-gnu": "0.14.0",
-    "@badness/linux-x64-musl": "0.14.0",
-    "@badness/linux-arm64-musl": "0.14.0",
-    "@badness/darwin-x64": "0.14.0",
-    "@badness/darwin-arm64": "0.14.0",
-    "@badness/win32-x64": "0.14.0",
-    "@badness/win32-arm64": "0.14.0"
+    "@badness/linux-x64-gnu": "0.15.0",
+    "@badness/linux-arm64-gnu": "0.15.0",
+    "@badness/linux-x64-musl": "0.15.0",
+    "@badness/linux-arm64-musl": "0.15.0",
+    "@badness/darwin-x64": "0.15.0",
+    "@badness/darwin-arm64": "0.15.0",
+    "@badness/win32-x64": "0.15.0",
+    "@badness/win32-arm64": "0.15.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.15.0](https://github.com/jolars/badness/compare/v0.14.0...v0.15.0) (2026-08-07)

### Features
- **formatter:** default every file kind to reflow ([`ba9f2f9`](https://github.com/jolars/badness/commit/ba9f2f9dde4d8f50e073f53b6fd0b643787c0539))
- **formatter:** add a line-ending style ([`373a16c`](https://github.com/jolars/badness/commit/373a16c5012b53d4d8f500e19f396e0c66728aa2))
- **wasm:** add `badness-wasm` playground shim crate ([`6486890`](https://github.com/jolars/badness/commit/648689051f65d7729a27821605ea1473e967be6b))

### Bug Fixes
- **formatter:** hug detonating atoms in fallback fills ([`db63ddb`](https://github.com/jolars/badness/commit/db63ddbf49cf58bc5534106894131e9a2686bec1))
- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
- **linter:** skip parameter-template keys in key scans ([`928aa4a`](https://github.com/jolars/badness/commit/928aa4ace51aa193430a1445f9d7d6afacff8f2e)), closes [#104](https://github.com/jolars/badness/issues/104)
- **formatter:** keep fitting math segments flat ([`903ec3e`](https://github.com/jolars/badness/commit/903ec3e240023ea1f68af3b8a1a78d4151b3e97d))

### Dependencies
- updated crates/badness-formatter to v0.2.0
- updated crates/badness-parser to v0.1.1

## [crates/badness-formatter: 0.2.0](https://github.com/jolars/badness/compare/badness-formatter-v0.1.0...badness-formatter-v0.2.0) (2026-08-07)

### Features
- **formatter:** default every file kind to reflow ([`ba9f2f9`](https://github.com/jolars/badness/commit/ba9f2f9dde4d8f50e073f53b6fd0b643787c0539))
- **formatter:** add a line-ending style ([`373a16c`](https://github.com/jolars/badness/commit/373a16c5012b53d4d8f500e19f396e0c66728aa2))

### Bug Fixes
- **formatter:** hug detonating atoms in fallback fills ([`db63ddb`](https://github.com/jolars/badness/commit/db63ddbf49cf58bc5534106894131e9a2686bec1))
- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
- **formatter:** keep fitting math segments flat ([`903ec3e`](https://github.com/jolars/badness/commit/903ec3e240023ea1f68af3b8a1a78d4151b3e97d))

### Dependencies
- updated crates/badness-parser to v0.1.1

## [crates/badness-parser: 0.1.1](https://github.com/jolars/badness/compare/badness-parser-v0.1.0...badness-parser-v0.1.1) (2026-08-07)

### Bug Fixes
- **formatter:** accept a relation as an expl3 `N` slot ([`4a3d92b`](https://github.com/jolars/badness/commit/4a3d92b908081b34c0899f471efabe8d573e3c3e)), closes [#106](https://github.com/jolars/badness/issues/106)
- **formatter:** gate the expl3 forced-break dispatch in fallback lines ([`7437f69`](https://github.com/jolars/badness/commit/7437f692b549ef64f7450e4e63450ba09943181b))
- **linter:** skip parameter-template keys in key scans ([`928aa4a`](https://github.com/jolars/badness/commit/928aa4ace51aa193430a1445f9d7d6afacff8f2e)), closes [#104](https://github.com/jolars/badness/issues/104)

## [editors/code: 0.15.0](https://github.com/jolars/badness/compare/badness-code-v0.14.0...badness-code-v0.15.0) (2026-08-07)

### Dependencies
- updated badness to v0.15.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).