### PR TITLE
perf(parser): one batch driver for all nine shape gates

### DIFF
--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -123,9 +123,10 @@ Prefer false negatives; when in doubt a construct stays generic.
   a later `\fi` must still be consumed by the refuted entry's slot
   (`a_refuted_nested_opener_still_consumes_a_fi`). The batch is a **shared
   driver** (`Parser::gate_batch`), not this gate's own machinery: it owns the
-  bookkeeping every gate repeats and takes a `GatePolicy` per gate. Add a hook
-  when a migrating gate needs one (container-stack C2); never average two gates'
-  policies into the loop.
+  bookkeeping every gate repeats and takes a `GatePolicy` per gate. All eight
+  gates run on it (container-stack C2 is complete); never average two gates'
+  policies into the loop — where two read the same token differently, add a
+  named axis with its reason, and say whether it was *chosen* or *preserved*.
 - **Environment aliases pair behind a *positive* gate** (#109). A command whose
   body is exactly `\begin{X}`/`\end{X}` stands in for that delimiter. Target must
   be curated built-in, non-verbatim, argument-free; alias must be arity 0; both
@@ -161,7 +162,11 @@ Prefer false negatives; when in doubt a construct stays generic.
   `environment_escapes_group` (every `\begin{…}` carries a `}` in its own name
   group, so the index sits near EOF; batched in C2.2). Scan work is metered
   (`Parser::scan_work`) and pinned linear by the tests in `grammar.rs` — extend
-  them when touching a gate.
+  them when touching a gate. Two shapes stay quadratic **by design** and say so
+  in their tests rather than pretending otherwise: a `${` per line (the brace
+  depth ratchets upward, so no later opener sits at the seed's level) and a
+  `macrocode` chunk of `\cmd[` openers whose only `]` is past the frame (that
+  gate is single-entry by policy).
 
 - **`.dtx` frames are asymmetric about column 0**: a begin frame may be indented
   (`\MakePercentIgnore`), an end frame is column-0 strict.
@@ -179,7 +184,28 @@ Prefer false negatives; when in doubt a construct stays generic.
   the starred-variant fold.
 - **A bracket attaches only when it reads as an argument.** In math: directly
   abutting with its `]` reachable before the math ends, net of intervening
-  claims. In text: mirroring the `$` gate.
+  claims. In text: mirroring the `$` gate. All three run on the batch driver
+  (container-stack C2.5) as `TextBracketGate`/`MathBracketGate`/
+  `MacrocodeBracketGate`. The `]`-claim countdown of #55 **is** the driver's
+  nested-opener stack once an opener is a command-abutting `[` — no new nesting
+  model — and both of the family's anchors are depth-**blind**
+  (`EnvAnchor::Refutes`, `ParagraphAnchor::AnyDepth`) because `optional` bails
+  wherever the cursor stands. A `$` in math reads the enclosing math's *flavor*
+  (`dollar_anchor`, the one runtime policy): inside `\[…\]` it opens a
+  **transparent** region where the entries' own brackets stop counting; inside
+  `$…$` it is that math's closer and refuses (#99). Flavor is walk state, so it
+  rides `WalkKey`.
+- **Three bracket divergences are preserved, not chosen** — flipping one is its
+  own commit with its own test. The in-math gate's environment anchor ignores
+  `in_macro_code` and its braces ignore `plain_braces`; both only ever *decline*
+  to attach, and the second is arguably the faithful reading, since `optional`
+  bails at any `R_BRACE` without consulting `plain_braces` (so its two siblings
+  are the loose ones: an attached optional holding a chunk-plain `}` still
+  reports "unclosed `[`"). The `macrocode` gate skips only whitespace in its
+  paragraph run, so a guard line **breaks** it where every other gate floats it
+  — the `saw_blank_line_outside_guards` reading of #71, corpus-reachable and
+  load-bearing (`rotating.dtx`'s `\ProvidesPackage` date optional spans three
+  guard lines in one chunk; `a_guard_line_does_not_part_a_macrocode_optional`).
 - **Arity-directed expl3 attachment is a recorded candidate, deliberately
   unimplemented.** Do not implement without answering the three open questions
   in `TODO.md` (mixed-shape CST, false-positive blast radius moving into the

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -75,10 +75,13 @@ Prefer false negatives; when in doubt a construct stays generic.
   formatter owns layout there; linter: `\def` bodies withheld entirely, since a
   carried `\let` must not arm the operand countdown). Subtracting the
   brace-argument `if*` family is load-bearing, since shape alone mis-pairs rather
-  than fails. Demotes silently. One forward scan per live opener, bounded by the
-  last `\fi`-flavored word in the file; every ordinary anchor cuts it short, so
-  real corpora are unaffected — the residual shape (openers whose lone `\fi`
-  sits at EOF) is the container-stack roadmap's C1 in `TODO.md`.
+  than fails. Demotes silently. Verdicts come in **batches** (container-stack
+  C1): one scan, bounded by the last `\fi`-flavored word in the file, settles
+  every same-frame opener it passes, memoized against the walk state it read.
+  The batch's load-bearing rule: a refuted entry is **settled, never removed** —
+  the per-opener model counts nested openers by name and never un-counts one, so
+  a later `\fi` must still be consumed by the refuted entry's slot
+  (`a_refuted_nested_opener_still_consumes_a_fi`).
 - **Environment aliases pair behind a *positive* gate** (#109). A command whose
   body is exactly `\begin{X}`/`\end{X}` stands in for that delimiter. Target must
   be curated built-in, non-verbatim, argument-free; alias must be arity 0; both

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -56,7 +56,13 @@ Prefer false negatives; when in doubt a construct stays generic.
 - **Environment pairing is gated on brace structure**, not a command set: an
   environment cannot outlive the brace group its `\begin` opened in (#71,
   generalizing #45/#55). `.dtx` doc-margin lines are exempt from stranded
-  braces; a demoted `\begin` demotes its orphaned `\end` in step.
+  braces; a demoted `\begin` demotes its orphaned `\end` in step. Batched as
+  `EnvGate` (container-stack C2.2), the driver's first **demotion** gate, so its
+  verdict reads inverted (`Some` = escapes = demote) and two policies flip with
+  it: a stray `}` *closes* rather than refutes, and math is not an anchor —
+  refusing there would keep an environment the scan cannot vouch for. The
+  `group_depth` and doc-margin pre-checks are per-opener walk state and stay
+  outside the batch.
 - **`$`, `\[`, `\(` open math only when a closer is reachable** before an
   unbalanced `}`, an unowed `\end`, a paragraph break, chunk end, or EOF. The
   paragraph-break anchor applies only between top-level atoms of the math body.
@@ -112,10 +118,13 @@ Prefer false negatives; when in doubt a construct stays generic.
   one closer token shape, so truncating its scan at the last occurrence in the
   file is verdict-preserving — past it only refusals remain — and a file with
   none refuses without scanning. Recording may over-approximate, never
-  under-approximate. The exceptions are recorded in `TODO.md` (container stack):
-  `dollar_closes` (its closer is its opener's own token kind, so the bound is
-  vacuous) and, in practice, `environment_escapes_group` (every `\begin{…}`
-  carries a `}` in its own name group). Scan work is metered
+  under-approximate. A bound helps only a file with *no* closer, so a single
+  reachable closer at EOF defeats it for every gate — which is what the batch
+  driver, not the bound, is for. The gates where the bound is useless even
+  without that: `dollar_closes` (its closer is its opener's own token kind, so
+  the bound is vacuous) and `environment_escapes_group` (every `\begin{…}`
+  carries a `}` in its own name group, so the index sits near EOF; batched in
+  C2.2). Scan work is metered
   (`Parser::scan_work`) and pinned linear by the tests in `grammar.rs` — extend
   them when touching a gate.
 

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -66,6 +66,21 @@ Prefer false negatives; when in doubt a construct stays generic.
 - **`$`, `\[`, `\(` open math only when a closer is reachable** before an
   unbalanced `}`, an unowed `\end`, a paragraph break, chunk end, or EOF. The
   paragraph-break anchor applies only between top-level atoms of the math body.
+  Both run on the shared batch driver (container-stack C2.3) as `DollarGate` and
+  `DelimMathGate`, **single-entry**: they open no nested entry, so a batch
+  settles its seed alone — a delimiter that pairs swallows every opener up to
+  its closer, so there is no same-frame neighbor to settle. Four policies invert
+  against the pairing gates: a `}` refuses whether or not a group encloses the
+  opener (`StrayBrace::RefutesAlways`, mirroring `dollar_math`/`delim_math`,
+  which bail at any unbalanced `}`), a foreign math delimiter is content rather
+  than an anchor, environments count at *any* brace depth, and the closer needs
+  no environment balance. They also read a `macrocode` frame as an ordinary
+  environment rather than a hard boundary — preserved from the pre-batch scans,
+  not chosen; nothing in the corpora depends on it. The `$` gate is
+  **unmemoized**: a demoted `$$` re-enters on its second `$` with
+  `display: false`, a different question about the same index under the same
+  walk state, which a walk-state-keyed slot would answer from the first verdict
+  (`demoted_display_dollar_regates_its_second_dollar_as_inline`).
 - **`\if…\else…\or…\fi` pairs only when the `\fi` is reachable at the opener's
   own brace, environment, *and* math level**; a `macrocode` frame bounds it both
   ways, and the walk is bounded by the located closer index. A gate that counts a
@@ -120,11 +135,12 @@ Prefer false negatives; when in doubt a construct stays generic.
   none refuses without scanning. Recording may over-approximate, never
   under-approximate. A bound helps only a file with *no* closer, so a single
   reachable closer at EOF defeats it for every gate — which is what the batch
-  driver, not the bound, is for. The gates where the bound is useless even
-  without that: `dollar_closes` (its closer is its opener's own token kind, so
-  the bound is vacuous) and `environment_escapes_group` (every `\begin{…}`
-  carries a `}` in its own name group, so the index sits near EOF; batched in
-  C2.2). Scan work is metered
+  driver, not the bound, is for. **Every** gate names one, since the driver
+  takes it as `GatePolicy::last_closer` and refuses without scanning when it is
+  absent — including the two where it rarely bites: `dollar_closes` (its closer
+  is its opener's own token kind, so a file of openers ends at one) and
+  `environment_escapes_group` (every `\begin{…}` carries a `}` in its own name
+  group, so the index sits near EOF; batched in C2.2). Scan work is metered
   (`Parser::scan_work`) and pinned linear by the tests in `grammar.rs` — extend
   them when touching a gate.
 

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -81,6 +81,25 @@ Prefer false negatives; when in doubt a construct stays generic.
   `display: false`, a different question about the same index under the same
   walk state, which a walk-state-keyed slot would answer from the first verdict
   (`demoted_display_dollar_regates_its_second_dollar_as_inline`).
+- **`\left` opens a pair only when its `\right` is reachable**; otherwise it is a
+  plain command with no diagnostic (#77), a likely typo being linter territory.
+  Runs on the driver as `LeftRightGate` (container-stack C2.4), the only gate
+  whose entries **stack** instead of counting (`Nesting::Interleaved`): a pair
+  closes by count wherever it sits, so `{`, `\begin`, and `\left` share one LIFO
+  stack, and the two halves of that read differently. A frame **mismatch** (an
+  `\end` or a `\right` meeting a frame of the wrong kind) refuses the whole scan,
+  since the innermost frame is common to every outer entry
+  (`an_end_inside_a_nested_left_refuses_the_whole_scan`); the *absence* of frames
+  the blank-line anchor tests is seen only by the innermost entry, so a nested
+  pair **shields** the ones around it
+  (`a_nested_left_shields_the_outer_pair_from_a_paragraph_break` — where the gate
+  is looser than the walk, which bails at the break; pre-existing, preserved by
+  the migration). Its math anchor is the *closing* side (`MathAnchor::Closing`):
+  a `\left` lives inside math already, so `$`/`\]`/`\)` end it while a `\[` is
+  content. **Opener and closer recognition ignores `in_macro_code` on purpose**
+  where the driver's `\begin`/`\end` counting does not — the pair is
+  catcode-neutral and a `\def` body or `macrocode` chunk is exactly where
+  `$\left#2\right#4$` lives (#95). Do not "fix" that asymmetry.
 - **`\if…\else…\or…\fi` pairs only when the `\fi` is reachable at the opener's
   own brace, environment, *and* math level**; a `macrocode` frame bounds it both
   ways, and the walk is bounded by the located closer index. A gate that counts a

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -123,7 +123,7 @@ Prefer false negatives; when in doubt a construct stays generic.
   a later `\fi` must still be consumed by the refuted entry's slot
   (`a_refuted_nested_opener_still_consumes_a_fi`). The batch is a **shared
   driver** (`Parser::gate_batch`), not this gate's own machinery: it owns the
-  bookkeeping every gate repeats and takes a `GatePolicy` per gate. All eight
+  bookkeeping every gate repeats and takes a `GatePolicy` per gate. All nine
   gates run on it (container-stack C2 is complete); never average two gates'
   policies into the loop — where two read the same token differently, add a
   named axis with its reason, and say whether it was *chosen* or *preserved*.

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -75,9 +75,10 @@ Prefer false negatives; when in doubt a construct stays generic.
   formatter owns layout there; linter: `\def` bodies withheld entirely, since a
   carried `\let` must not arm the operand countdown). Subtracting the
   brace-argument `if*` family is load-bearing, since shape alone mis-pairs rather
-  than fails. Demotes silently. One forward scan per live opener; every ordinary
-  anchor cuts it short, so real corpora are unaffected — see `TODO.md` for the
-  pathological shape.
+  than fails. Demotes silently. One forward scan per live opener, bounded by the
+  last `\fi`-flavored word in the file; every ordinary anchor cuts it short, so
+  real corpora are unaffected — the residual shape (openers whose lone `\fi`
+  sits at EOF) is the container-stack roadmap's C1 in `TODO.md`.
 - **Environment aliases pair behind a *positive* gate** (#109). A command whose
   body is exactly `\begin{X}`/`\end{X}` stands in for that delimiter. Target must
   be curated built-in, non-verbatim, argument-free; alias must be arity 0; both
@@ -96,6 +97,17 @@ Prefer false negatives; when in doubt a construct stays generic.
   delimiter; the name-keyed `Signatures::environment` never reads it. A literal
   `\begin{bea}` beside an alias `\bea` is an unrelated environment and inherits
   nothing — that is why aliases are a side map, not a cloned `EnvironmentSig`.
+- **Every shape gate is bounded by its last-closer index** (the
+  `last_alias_closer` treatment, container-stack C0). A gate can only succeed at
+  one closer token shape, so truncating its scan at the last occurrence in the
+  file is verdict-preserving — past it only refusals remain — and a file with
+  none refuses without scanning. Recording may over-approximate, never
+  under-approximate. The exceptions are recorded in `TODO.md` (container stack):
+  `dollar_closes` (its closer is its opener's own token kind, so the bound is
+  vacuous) and, in practice, `environment_escapes_group` (every `\begin{…}`
+  carries a `}` in its own name group). Scan work is metered
+  (`Parser::scan_work`) and pinned linear by the tests in `grammar.rs` — extend
+  them when touching a gate.
 
 - **`.dtx` frames are asymmetric about column 0**: a begin frame may be indented
   (`\MakePercentIgnore`), an end frame is column-0 strict.

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -81,7 +81,11 @@ Prefer false negatives; when in doubt a construct stays generic.
   The batch's load-bearing rule: a refuted entry is **settled, never removed** —
   the per-opener model counts nested openers by name and never un-counts one, so
   a later `\fi` must still be consumed by the refuted entry's slot
-  (`a_refuted_nested_opener_still_consumes_a_fi`).
+  (`a_refuted_nested_opener_still_consumes_a_fi`). The batch is a **shared
+  driver** (`Parser::gate_batch`), not this gate's own machinery: it owns the
+  bookkeeping every gate repeats and takes a `GatePolicy` per gate. Add a hook
+  when a migrating gate needs one (container-stack C2); never average two gates'
+  policies into the loop.
 - **Environment aliases pair behind a *positive* gate** (#109). A command whose
   body is exactly `\begin{X}`/`\end{X}` stands in for that delimiter. Target must
   be curated built-in, non-verbatim, argument-free; alias must be arity 0; both

--- a/.claude/rules/parser.md
+++ b/.claude/rules/parser.md
@@ -98,7 +98,10 @@ Prefer false negatives; when in doubt a construct stays generic.
   bound the walk by it, EOF does not pair), **not** on the `\begin` demotion
   gate, and has no paragraph anchor. Demotes silently. Bound the walk by the last
   closer in the file and memoize the verdict — the caller asks twice, and openers
-  that never pair are otherwise quadratic. Not extended to `math_atom` in v1.
+  that never pair are otherwise quadratic. Runs on the shared batch driver as
+  `AliasGate` (container-stack C2.1); its only policy divergences from
+  `ConditionalGate` are the absent paragraph anchor and the closer's name match
+  (`GatePolicy::pairs`). Not extended to `math_atom` in v1.
 - **Alias behavior resolves from the node, never the name.**
   `Signatures::environment_at` reads the alias map only for a `Begin::is_alias`
   delimiter; the name-keyed `Signatures::environment` never reads it. A literal

--- a/TODO.md
+++ b/TODO.md
@@ -886,11 +886,29 @@ sources below are missing.
     anchor ever fires); and `environment_escapes_group` in practice,
     since every `\begin{…}` carries a `}` in its own name group, pushing
     the bound to EOF.
-  - [ ] **C1 — conditionals first.** The gate with the measured pathological
-    case and the cleanest policy (its level tracking is already explicit:
-    brace, environment, math, macrocode). Build the closer map in the
-    existing pre-scan pass; opener recognition stays in
-    `parser::conditional`, shared with the linter's `ConditionalIndex`.
+  - [x] **C1 — conditionals first** (done, with the mechanism amended). Not
+    a `new()`-time map after all: `conditional_closer` reads walk state —
+    above all `in_def_body`, which is set during greedy argument attachment,
+    so precomputing it in the pre-scan would mean re-implementing attachment
+    outside the walk, the very transcription-drift disease this item exists
+    to cure. Instead the gate is *batched*
+    (`Parser::conditional_closers_from`): one scan seeded at the queried
+    opener settles every same-frame opener it passes — nested openers are
+    counted only at brace depth 0, so they share the seed's frame exactly
+    and `\fi` matching is pure LIFO over a pending stack — memoized against
+    the walk state the scan read (`macrocode_end`, `in_def_body`,
+    `group_depth > 0`; `plain_braces` is pinned by the frame, everything
+    else is pre-scanned token state). One rule is load-bearing: a refuted
+    entry is **settled, never popped**, because the per-opener scan counts
+    nested openers by name and never un-counts one, so a later `\fi` must
+    still be consumed by the refuted entry's slot
+    (`a_refuted_nested_opener_still_consumes_a_fi` — popping instead hands
+    the `\fi` to the outer opener and builds a `CONDITIONAL` the per-opener
+    scan never did). Opener recognition stayed in `parser::conditional`,
+    shared with the linter's `ConditionalIndex`. The
+    openers-with-one-`\fi`-at-EOF shape, which defeats the C0 bound, is now
+    one linear pass (~34ms for 8000 openers end-to-end), pinned by
+    `conditional_batch_keeps_shared_frame_openers_linear`.
   - [ ] **C2 — migrate the remaining gates one at a time**, easiest policy
     first: alias, then `environment_escapes_group`, the math and bracket
     family last. Each migration deletes one transcribed scan and its copy of

--- a/TODO.md
+++ b/TODO.md
@@ -971,13 +971,38 @@ sources below are missing.
       measures. Adversarial shape (N openers, one closer at EOF) at
       1000/2000/4000: 15/59/192ms before, 9/18/46ms after, pinned by
       `alias_batch_keeps_shared_frame_openers_linear`.
-    - [ ] **C2.2 — `environment_escapes_group`.** The biggest measured win,
-      and the polarity inverts: it is a *demotion* gate, so an entry still
-      live at the end settles `false` (pairs), which is what preserves the
-      unclosed-environment diagnostic. The per-opener pre-checks
-      (`group_depth == 0`, `doc_margin_exempt`) stay outside the batch — they
-      short-circuit before any scan and read per-opener walk state.
-      `end_orphans_a_demoted_begin` is untouched.
+    - [x] **C2.2 — `environment_escapes_group`** (done). `EnvGate` is the
+      driver's first *demotion* gate, and three policies invert with it, each
+      a new hook: a stray `}` **closes** instead of refuting
+      (`StrayBrace::Closes` — same token event, opposite verdict), math is
+      **not** an anchor (`MATH_REFUTES = false`; for a positive gate refusing
+      behind a math delimiter is the conservative direction, here it would
+      *keep* an environment the scan cannot vouch for, and the pre-batch scan
+      had no math anchor), and the openers are themselves `\begin`s
+      (`OPENER_IS_ENV_BEGIN`, so the driver counts one in `envs` before
+      pushing its entry — an entry's `envs_at_push` must exclude its own
+      environment, which its per-opener scan never saw). `\end` stays the
+      level anchor rather than a closer, and running out of file still keeps
+      the environment, so `finish_environment`'s unclosed-environment
+      diagnostic and `end_orphans_a_demoted_begin` are untouched. The
+      `group_depth == 0` and `doc_margin_exempt` pre-checks stay outside the
+      batch: they are per-opener walk state, so they are applied per query and
+      a rejected opener never consults the batch at all. Shadow differential
+      green over the suite, all four corpora, and a torture file (escape past
+      inline and display math, nested `\begin`s where the outer escapes and
+      the inner pairs, two openers on one brace, a `macrocode` opener, nested
+      groups).
+
+      **Measured, and it corrects the attribution above.** Gate scan work is
+      now exactly linear (5 ticks per opener: 2500/5000/10000 at n =
+      500/1000/2000). Parse-side wall clock on the escaping shape (`{`, N
+      `\begin{itemize}`, one `}`) at 2000/4000/8000 went 36/114/407ms →
+      19/20/34ms, quadratic to flat. But `format --check` on the same files
+      only went 79/196/512ms → 46/133/462ms, because **a second quadratic
+      lives downstream in the formatter**: `lint` (lex, parse, lint) is
+      linear at 19/20/34ms while `format --check` is 42/135/455ms on the
+      identical input. The 69/230/984ms figures in the C2 preamble are
+      end-to-end and so were never the gate's alone. New item below.
     - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
       environments at *any* brace depth, unlike the conditional and `\begin`
       gates: a driver knob, an explicit divergence. `dollar` is the
@@ -1029,6 +1054,16 @@ sources below are missing.
     stepping stone to the map; C2.0 keeps that order by *extracting* the
     driver from C1's working batch rather than authoring a
     lowest-common-denominator scan.
+- [ ] **The formatter is superlinear in a group's child count** (found while
+  measuring C2.2, and it is the *other* half of every "quadratic gate" number
+  recorded above). On `{`, N `\begin{itemize}`, `}` — one brace group with N
+  demoted commands in it — `badness lint` (lex, parse, lint) is flat at
+  19/20/34ms for N = 2000/4000/8000 while `badness format --check` on the same
+  files is 42/135/455ms, growing ~3.4x per doubling. The parser is no longer
+  implicated, so it is lowering or printing. Profile it (`task bench:profile`
+  takes `BADNESS_BENCH_DOC`) before guessing; the shape is degenerate, but a
+  real `.sty` with a few thousand siblings in one group is not far off, and the
+  gate work this roadmap has been shaving is now the smaller term.
 - [ ] **Fuzz/property losslessness harness — the one missing oracle layer.**
   Everything today is curated corpus + snapshots; nothing exercises
   `PARSER_STEP_LIMIT` or the recovery paths with arbitrary bytes, and

--- a/TODO.md
+++ b/TODO.md
@@ -885,7 +885,9 @@ sources below are missing.
     the bound is vacuous (`${` per line ratchets depth upward and no
     anchor ever fires); and `environment_escapes_group` in practice,
     since every `\begin{…}` carries a `}` in its own name group, pushing
-    the bound to EOF.
+    the bound to EOF. That list turned out to be too short: the bound only
+    helps a file with *no* closer, so a single reachable closer at EOF
+    defeats it for every gate (measured under C2).
   - [x] **C1 — conditionals first** (done, with the mechanism amended). Not
     a `new()`-time map after all: `conditional_closer` reads walk state —
     above all `in_def_body`, which is set during greedy argument attachment,
@@ -909,19 +911,114 @@ sources below are missing.
     openers-with-one-`\fi`-at-EOF shape, which defeats the C0 bound, is now
     one linear pass (~34ms for 8000 openers end-to-end), pinned by
     `conditional_batch_keeps_shared_frame_openers_linear`.
-  - [ ] **C2 — migrate the remaining gates one at a time**, easiest policy
-    first: alias, then `environment_escapes_group`, the math and bracket
-    family last. Each migration deletes one transcribed scan and its copy of
-    the bookkeeping.
-  - [ ] **C3 — decide whether to finish.** If the math-gate restatement
-    proves too entangled, stopping with conditionals and aliases on the map
-    and the math/bracket gates on a shared scan skeleton (one struct owning
-    bound computation, brace/env/blank-line bookkeeping, and the
-    macrocode-frame refusal, with per-gate closures keeping the deliberate
-    divergences explicit) is a respectable end-state — the skeleton and the
-    map are two depths of the same consolidation, chosen per gate. Do **not**
-    build the skeleton first as a stepping stone to the map; it is the
-    fallback, not the foundation.
+  - [ ] **C2 — migrate the remaining gates onto one batch driver**, easiest
+    policy first: alias, then `environment_escapes_group`, then the math and
+    bracket family. This item's original wording ("each migration deletes one
+    transcribed scan and its copy of the bookkeeping") belongs to the
+    `new()`-time map C1 abandoned. Every remaining gate reads walk state as
+    well — `in_def_body`, `group_depth`, `plain_braces`, `macrocode_end`, and
+    `math_dollar.last()` for `bracket_closes_before_math_end` — so each is a
+    *batch*, not a precomputation, and repeating C1 by hand six times would
+    leave nine copies of a scan **plus** seven copies of the batch machinery:
+    the transcription-drift disease this item exists to cure, made worse. So
+    the driver comes first, and each gate joins it.
+
+    The residuals are also wider than C0 recorded. C0 named `dollar_closes`
+    and `environment_escapes_group`, but its bound only helps a file with *no*
+    closer, so **one reachable closer at EOF defeats it for every gate**. N
+    openers, one closer, no anchors in reach, `format --check` end to end at
+    2000/4000/8000: `environment_escapes_group` (`{` then N `\begin{itemize}`)
+    69/230/984ms; `bracket_closes_in_text` (N `\cmd[`, one `]`) 31/102/271ms;
+    `left_right_closes` (N `\left(`, one `\right)`) 22/68/230ms;
+    `dollar_closes` (N `${`) 15/48/180ms. `delim_math_closes` measures linear
+    on its own shape, and alias needs both halves defined in the same file, so
+    those two are migrated for uniformity rather than for speed.
+
+    - [ ] **C2.0 — extract the batch driver; re-express conditionals on it.**
+      Lift `conditional_closers_from`'s engine into a reusable scan owning
+      only the *bookkeeping*: the bound (`macrocode_end` ∧ `tokens.len()` ∧
+      last closer + 1), trivia skip, newline runs, brace depth under
+      `plain_braces`, environment counting with the `macrocode`-frame break in
+      both directions, the `group_depth > 0` stray-`}` rule, the
+      `pending`/`live` stack with `envs_at_push`, settled-never-popped,
+      `tick_scan` metering, and the walk-state memo. Per-gate policy stays an
+      explicit struct of named hooks (`is_opener`, `closer_at`,
+      `paragraph_anchors`, `env_counting`, `on_math`, `eof_verdict`), each
+      keeping the doc comment it carries today: the driver owns the
+      bookkeeping and never averages the policies. No behavior change; the
+      existing conditional tests pin it. This is not the C3 skeleton built
+      first — the driver is *extracted from C1's working batch*, so the map
+      stays the foundation and C3 becomes a subtraction rather than a
+      construction. Two fixes belong in the extraction: give `plain_braces` a
+      version counter bumped in `macrocode_body` so the memo key is a fact
+      instead of the current "pinned by the frame" argument, and hoist
+      **settled-never-popped** into the driver, since every remaining gate has
+      the same never-un-counted nested-opener countdown (`nested` for alias,
+      `brackets` for the bracket pair, the `Ctx::Left` stack for `\left`) and
+      every new policy must answer for it explicitly.
+    - [ ] **C2.1 — alias.** Conditional's policy minus the paragraph anchor,
+      plus the named-closer test (`closing == target`); retires
+      `alias_closer_memo` into the shared memo. Low value, low risk: its job
+      is to shape the abstraction with a second client before the expensive
+      ones arrive.
+    - [ ] **C2.2 — `environment_escapes_group`.** The biggest measured win,
+      and the polarity inverts: it is a *demotion* gate, so an entry still
+      live at the end settles `false` (pairs), which is what preserves the
+      unclosed-environment diagnostic. The per-opener pre-checks
+      (`group_depth == 0`, `doc_margin_exempt`) stay outside the batch — they
+      short-circuit before any scan and read per-opener walk state.
+      `end_orphans_a_demoted_begin` is untouched.
+    - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
+      environments at *any* brace depth, unlike the conditional and `\begin`
+      gates: a driver knob, an explicit divergence. `dollar` is the
+      interesting one — its closer is its own opener's token kind, so entries
+      chain (each depth-0 `$` settles the previous entry and pushes itself)
+      and `display` becomes per-entry state. This is what finally kills the
+      `${`-per-line shape C0 recorded as unreachable by bounding.
+    - [ ] **C2.4 — `left_right_closes`.** A third environment-counting mode: a
+      brace group is opaque, skipped wholesale. Also the one gate whose
+      opener/closer recognition deliberately ignores `in_macro_code` (issue
+      \#95) — the fix that lives in exactly one copy today, and the concrete
+      payoff of consolidating.
+    - [ ] **C2.5 — the bracket family** (`bracket_closes_in_text`,
+      `bracket_closes_before_math_end`,
+      `bracket_closes_before_macrocode_end`). The `abuts_command` claim
+      countdown *is* the driver's nested-opener stack once an "opener" is
+      defined as a command-abutting `[`. Two things to settle first:
+      `bracket_closes_before_math_end` must carry `math_dollar.last()` in its
+      memo key, and it is the only bracket gate that does **not** filter
+      `plain_braces` on `L_BRACE`/`R_BRACE` — decide whether that is
+      deliberate or a latent macrocode bug before preserving it into the
+      driver.
+
+    **Migration technique**, per stage: keep the old per-opener scan as a
+    `#[cfg(debug_assertions)]` reference and assert `batch(open) ==
+    reference(open)` on every query for the life of the migration commit, run
+    the suite and a debug corpus pass, then delete the reference before
+    merging. C2's correctness claim is stronger than C1's one-directional
+    contract — verdicts must be *bit-identical* to the per-opener scan under
+    the same walk state — and this makes it mechanically checkable.
+
+    **Acceptance gate**, identical at every stage, one commit per stage:
+    `cargo test` plus snapshots; `task gate-corpora:check` (two-sided ratchet,
+    sets not counts); `task parse-compat` and `task bib-parse-compat`
+    **unchanged**, since a verdict-preserving migration must not move the
+    differential; a `<gate>_batch_stays_linear_with_one_closer_at_eof`
+    scan-work test per gate, on the shapes measured above; and `task
+    bench:micro` flat on real documents, so a memo miss never costs the common
+    case.
+  - [ ] **C3 — decide whether to finish.** Cheaper to decide once C2.0 has
+    landed: with the gates on one driver the question is whether any gate
+    stays on single-verdict runs, not whether to build a fallback. If the
+    math-gate restatement proves too entangled, stopping with conditionals and
+    aliases batched and the math/bracket gates running the same driver one
+    opener at a time — the bound, the brace/env/blank-line bookkeeping, and
+    the macrocode-frame refusal shared, the batch stack unused — is a
+    respectable end-state: the skeleton and the map are two depths of the same
+    consolidation, chosen per gate. Do **not** build the skeleton first as a
+    stepping stone to the map; C2.0 keeps that order by *extracting* the
+    driver from C1's working batch rather than authoring a
+    lowest-common-denominator scan.
 - [ ] **Fuzz/property losslessness harness — the one missing oracle layer.**
   Everything today is curated corpus + snapshots; nothing exercises
   `PARSER_STEP_LIMIT` or the recovery paths with arbitrary bytes, and

--- a/TODO.md
+++ b/TODO.md
@@ -956,11 +956,21 @@ sources below are missing.
       parse-compat report are unchanged, and `bench:micro` is flat within
       run-to-run noise (parse-only spread on the small documents is ±30%
       between runs either way).
-    - [ ] **C2.1 — alias.** Conditional's policy minus the paragraph anchor,
-      plus the named-closer test (`closing == target`); retires
-      `alias_closer_memo` into the shared memo. Low value, low risk: its job
-      is to shape the abstraction with a second client before the expensive
-      ones arrive.
+    - [x] **C2.1 — alias** (done). `AliasGate` is conditional's policy minus
+      the paragraph anchor, plus the named-closer test — the first client of
+      the defaulted `pairs` hook, which needed no driver change. The
+      `alias_closer_memo` slot became `alias_batch`, and its key widened from
+      `(opener, group_depth)` to the shared `WalkKey`, which also closes a
+      latent staleness hole: the old key omitted `in_def_body` even though the
+      scan reads it through `in_macro_code`. The shadow differential ran green
+      over the suite, all four corpora (release + `-C debug-assertions`), and
+      a torture file covering nesting, crossing, group escape, math, an
+      environment in the way, a closer inside one, mismatched names, a
+      definition body, and a paragraph-spanning body; then the reference came
+      out, since it ticks `scan_work` and so hides the very linearity the pin
+      measures. Adversarial shape (N openers, one closer at EOF) at
+      1000/2000/4000: 15/59/192ms before, 9/18/46ms after, pinned by
+      `alias_batch_keeps_shared_frame_openers_linear`.
     - [ ] **C2.2 — `environment_escapes_group`.** The biggest measured win,
       and the polarity inverts: it is a *demotion* gate, so an entry still
       live at the end settles `false` (pairs), which is what preserves the

--- a/TODO.md
+++ b/TODO.md
@@ -1026,22 +1026,63 @@ sources below are missing.
       more expensive on the same inputs anyway (item below), and that is where
       speed work belongs.
 
-    - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
-      environments at *any* brace depth, unlike the conditional and `\begin`
-      gates, and neither requires an environment balance at the closer — two
-      driver knobs, both explicit divergences. Their stray-`}` refusal is
-      unconditional where the positive gates' is `group_depth`-gated, so
-      `StrayBrace` grows a third variant. Neither treats a foreign math
-      delimiter as an anchor (`MATH_REFUTES = false`, as `EnvGate` already
-      sets). `dollar` adds two wrinkles: its closer is its own opener's token
-      kind, and a display `$$` opener starts the scan two tokens along — pass
-      the seed as `open + 1` from the caller rather than adding a hook, and
-      give `DollarGate` a `display` field for the "next token is `$`" test.
-      Run both **single-entry** (`opens_at` always false): their openers do
-      not nest — the first depth-0 closer answers every live opener at once —
-      so there is no LIFO to model and no closer-scope hook to add. `dollar`
-      also wants a `last_dollar` bound recorded in `new()` to keep the
-      `last_closer` contract honest.
+    - [x] **C2.3 — `delim_math_closes`, then `dollar_closes`** (done).
+      `DelimMathGate` and `DollarGate` are both **single-entry** as planned
+      (`opens_at` always false), and the plan's knobs all landed:
+      `ENVS_AT_ANY_DEPTH`, `CLOSER_NEEDS_ENV_BALANCE`, `MATH_REFUTES = false`,
+      and `StrayBrace`'s third variant — renamed as a trio
+      (`RefutesInGroup`/`ClosesInGroup`/`RefutesAlways`) so the `group_depth`
+      condition is in the name rather than in the driver. The display seed is
+      passed as `open + 1` from the caller, no hook. `last_dollar` is recorded.
+
+      Three things the plan did not have:
+
+      - **The `_`-arm widening had to come with C2.3, not C2.5.** These gates
+        close on a `DOLLAR` and a `CONTROL_SYMBOL`, so the driver had to ask
+        `opens_at`/`closes_at` for any token at the entries' own level before
+        either could run at all. Done, and it costs the narrow gates nothing
+        measurable (`bench:micro` parse-only within run-to-run noise on all
+        three documents). C2.5 inherits it.
+      - **A `macrocode` frame is not an anchor for these two.** The pre-batch
+        scans counted `\begin{macrocode}` as an ordinary environment where
+        every pairing gate treats the frame as a hard boundary — an
+        unanticipated divergence, kept as `MACROCODE_FRAME_ANCHORS` because
+        C2 migrates verdicts unchanged. Flipping it on is invisible to the
+        suite and to all four corpora but does change a `.dtx` doc-layer `\[`
+        that spans a chunk; if it should be unified, that is its own commit
+        with its own test, not a silent rider on a structural migration.
+      - **The `$` gate runs unmemoized** (`Parser::gate_verdict`). A memo slot
+        keyed on the walk state is not merely idle for a single-entry gate, it
+        is wrong: a demoted `$$` re-enters `element` on its *second* `$`, which
+        is the very index the display query seeded, under an unchanged walk
+        state, asking `display: false`. `$$ a $` is the shape — first `$`
+        plain, second opening inline math — pinned by
+        `demoted_display_dollar_regates_its_second_dollar_as_inline`.
+
+      Shadow differential green: the suite, a per-file pass over all 6277
+      corpus files with `-C debug-assertions`, and a torture `.tex`/`.dtx`
+      (closers inside groups, stray braces at both group depths, paragraph
+      breaks at and below the body's own level, issue #70's environment-nested
+      break, environments open at the closer, unowed `\end`, foreign
+      delimiters, lone `$` inside `$$`, macro-code data, definition bodies,
+      doc-layer openers scanning into a chunk, an opener inside one). The
+      harness bites: flipping `MACROCODE_FRAME_ANCHORS` for the experiment
+      above panicked on the torture `.dtx` at once.
+
+      **A process finding for C2.4/C2.5:** `task gate-corpora:check` does
+      **not** surface a panic — the per-file exit code is swallowed by the
+      distillation pipeline, and the flipped-knob build passed all eight
+      baselines while panicking on a four-line `.dtx`. Run the debug-assertions
+      binary file-by-file (`xargs -P8 -I{}`) as the shadow pass; the baseline
+      ratchet is a verdict check, not a panic check.
+
+      Linearity as measured (`parse` inside `bench:micro`, 1000/2000/4000
+      openers): `\[`-with-`\]`-at-EOF **178/340/681 µs**, exactly linear, and
+      pinned by `math_batch_stays_linear_with_one_closer_at_eof` for both
+      delim flavors and both `$` shapes. The `${` ratchet shape is unchanged
+      (38.6 → 35.9 ms end to end at n = 4000, the new bound if anything
+      helping), and stays quadratic by design — the test says so rather than
+      pinning a shape the gate cannot fix.
     - [ ] **C2.4 — `left_right_closes`.** A third environment-counting mode: a
       brace group is opaque, skipped wholesale. Also the one gate whose
       opener/closer recognition deliberately ignores `in_macro_code` (issue
@@ -1058,12 +1099,11 @@ sources below are missing.
       deliberate or a latent macrocode bug before preserving it into the
       driver.
 
-      One driver change these three share, and it is a *simplification*: ask
-      `opens_at`/`closes_at` for any non-trivia token at the entries' own
-      level instead of only for a `CONTROL_WORD`, since these gates' closers
-      are `DOLLAR`, `CONTROL_SYMBOL`, and `R_BRACKET`. The existing three
-      policies already test the token kind inside their own predicates, so
-      widening costs them nothing.
+      The driver change these three were to share — asking
+      `opens_at`/`closes_at` for any token at the entries' own level rather
+      than only for a `CONTROL_WORD` — **landed in C2.3**, which needed it for
+      its own `DOLLAR` and `CONTROL_SYMBOL` closers. An `R_BRACKET` closer is
+      already served.
 
     **Migration technique**, per stage: keep the old per-opener scan as a
     `#[cfg(debug_assertions)]` reference and assert `batch(open) ==

--- a/TODO.md
+++ b/TODO.md
@@ -915,9 +915,10 @@ sources below are missing.
     openers-with-one-`\fi`-at-EOF shape, which defeats the C0 bound, is now
     one linear pass (~34ms for 8000 openers end-to-end), pinned by
     `conditional_batch_keeps_shared_frame_openers_linear`.
-  - [ ] **C2 — migrate the remaining gates onto one batch driver**, easiest
-    policy first: alias, then `environment_escapes_group`, then the math and
-    bracket family. This item's original wording ("each migration deletes one
+  - [x] **C2 — migrate the remaining gates onto one batch driver** (done in
+    five stages, C2.1–C2.5; all eight gates now run on `Parser::gate_batch`),
+    easiest policy first: alias, then `environment_escapes_group`, then the
+    math and bracket family. This item's original wording ("each migration deletes one
     transcribed scan and its copy of the bookkeeping") belongs to the
     `new()`-time map C1 abandoned. Every remaining gate reads walk state as
     well — `in_def_body`, `group_depth`, `plain_braces`, `macrocode_end`, and
@@ -1147,22 +1148,76 @@ sources below are missing.
       `live` pointing past `pending` (the interleaved closer arm pops its entry
       first, and the corpus pass caught the panic at once), and the reference
       copy must not tick `scan_work` or it hides the linearity the pin measures.
-    - [ ] **C2.5 — the bracket family** (`bracket_closes_in_text`,
-      `bracket_closes_before_math_end`,
-      `bracket_closes_before_macrocode_end`). The `abuts_command` claim
-      countdown *is* the driver's nested-opener stack once an "opener" is
-      defined as a command-abutting `[`. Two things to settle first:
-      `bracket_closes_before_math_end` must carry `math_dollar.last()` in its
-      memo key, and it is the only bracket gate that does **not** filter
-      `plain_braces` on `L_BRACE`/`R_BRACE` — decide whether that is
-      deliberate or a latent macrocode bug before preserving it into the
-      driver.
+    - [x] **C2.5 — the bracket family** (done). The `abuts_command` claim
+      countdown *was* the driver's nested-opener stack, exactly as predicted —
+      an opener is a `[` whose previous token is a control word or symbol
+      (the running flag, which every other kind cleared, is that test one token
+      back), and closer matching is LIFO either way, so the family needed **no
+      new nesting model**. Both pre-questions settled:
 
-      The driver change these three were to share — asking
-      `opens_at`/`closes_at` for any token at the entries' own level rather
-      than only for a `CONTROL_WORD` — **landed in C2.3**, which needed it for
-      its own `DOLLAR` and `CONTROL_SYMBOL` closers. An `R_BRACKET` closer is
-      already served.
+      - **The memo key carries the flavor.** `WalkKey` gained
+        `enclosing_math_is_dollar`; nothing else in the key moves when it does,
+        since entering a `$` inside `\[…\]` changes no brace, group, or frame
+        state.
+      - **The missing `plain_braces` filter is not a latent macrocode bug — it
+        is arguably the *faithful* reading.** `Parser::optional` bails at any
+        `R_BRACE` without consulting `plain_braces`, so the in-math gate mirrors
+        the walk and its two siblings are the loose ones: an optional they let
+        attach over a chunk-plain `}` still reports "unclosed `[`" and blocks
+        the file for the formatter. It is also one-directional (a chunk-unmatched
+        `}` can only occur at chunk brace depth 0, so the scan meets it at its
+        own depth 0 and refuses, while a chunk-unmatched `{` only adds depth), so
+        the unfiltered reading refuses a bracket the filtered one attaches and
+        never the reverse. Preserved as `PLAIN_BRACES_ARE_TOKENS`; unifying is
+        its own commit, and the pre-existing gate/walk looseness above is the
+        thing to fix first.
+
+      What the family did need is **two anchors read depth-blind**
+      (`EnvAnchor::Refutes`, `ParagraphAnchor::AnyDepth`), because `optional`'s
+      own bail is depth-blind: it bails wherever the cursor stands, so a gate
+      reading either at the bracket's own brace level would attach an optional
+      the walk then reports unclosed. `ENVS_AT_ANY_DEPTH` widened to
+      `ANCHORS_AT_ANY_DEPTH` (the `\]`/`\)` arm joins the `\begin`/`\end` one),
+      verdict-preserving for all five earlier gates, since the two that set it
+      read math as content anyway. `DollarAnchor` is the driver's first
+      **runtime** policy — a `$` in `\[…\]` opens a *transparent* region where
+      the entries' own brackets stop counting, and inside `$…$` it refuses — and
+      it has to be a method because the flavor is walk state.
+
+      Two more preserved divergences, both named and both discriminated by the
+      torture pair:
+
+      - **`ENV_ANCHOR_IN_MACRO_CODE`** — the in-math gate's `\begin`/`\end`
+        anchor carries no `in_macro_code` filter, so it is *stricter* than the
+        `optional` bail it mirrors. Only ever declines to attach
+        (`a_math_bracket_anchors_on_an_environment_inside_macro_code` pins it
+        beside its text-mode twin, where the same body attaches).
+      - **`DOC_TRIVIA_FLOATS`** — the `macrocode` gate skips only `WHITESPACE`
+        in its paragraph run, so a docstrip guard line **breaks** the run where
+        every other gate floats it. This one is **corpus-reachable and
+        load-bearing**, the only knob of the whole C2 stack that is: flipping it
+        panicked the shadow reference on `rotating.dtx` and `rotex.tex`, whose
+        `\ProvidesPackage` date optional runs over three guard lines inside one
+        chunk. It is also the `saw_blank_line_outside_guards` reading (#71:
+        docstrip *deletes* a guard-only line, so it does not part what surrounds
+        it) — which means the *other* seven gates are the ones diverging from
+        the considered model, and unifying should move toward this gate, not
+        away. Recorded as its own item below.
+
+      **Measured** (`parse` alone via `bench:micro`, N openers with one closer
+      at EOF, 1000/2000/4000). Text (`\cmd[x` per line, one `]`):
+      **3.2/12.4/50.5 ms → 0.29/0.56/1.16 ms**, ~44x at n = 4000. In math (the
+      same run inside one `$…$`): **1.8/9.4/28.9 ms → 0.39/0.59/1.19 ms**, ~24x.
+      Both pinned by `bracket_batch_keeps_shared_frame_openers_linear`. The
+      `macrocode` gate is single-entry by policy (its scan ran no countdown), so
+      a chunk of `\cmd[` openers whose only `]` sits past the frame stays
+      quadratic; recorded in the test rather than pinned, like the `${` ratchet.
+      `bench:micro` flat on all four real documents.
+
+      Shadow differential green: the suite, a per-file debug-assertions pass over
+      all 6277 corpus files, and a `.tex`/`.dtx` torture pair discriminating all
+      six of the family's policy knobs (the `.dtx` half carries the three that
+      need a chunk). Baselines, `parse-compat`, `bib-parse-compat` unchanged.
 
     **Migration technique**, per stage: keep the old per-opener scan as a
     `#[cfg(debug_assertions)]` reference and assert `batch(open) ==
@@ -1189,6 +1244,30 @@ sources below are missing.
     bookkeeping, where a fix to one copy does not propagate (#95). One driver
     with named per-gate policies is the end-state. Revisit only if a gate's
     policy genuinely cannot be stated without averaging it against another's.
+
+  **What the finished driver left on the table** (both surfaced by C2.5, both
+  their own commit with their own test — C2 migrated verdicts unchanged):
+
+  - [ ] **A docstrip guard line parts a construct for seven of the eight
+    gates.** Only `MacrocodeBracketGate` reads the `saw_blank_line_outside_guards`
+    model (#71: docstrip *deletes* a guard-only line, so it does not part what
+    surrounds it); the driver's own trivia arm floats a `GUARD` like a margin,
+    so for every other gate the two newlines around `%<*dtx>` read as a blank
+    line. The bracket gate's reading is the considered one and is
+    corpus-load-bearing (`rotating.dtx`, `rotex.tex`), so unification should
+    move the driver *to* it — i.e. drop `DOC_TRIVIA_FLOATS` in favor of the
+    guard-breaking run everywhere, and re-baseline whatever that moves. Expect
+    it to *keep* constructs that are demoted today, so the risk is over-pairing,
+    not under-.
+  - [ ] **`optional` bails at a chunk-plain `}` its own gates skip.** Two of the
+    three bracket gates filter `plain_braces`; `Parser::optional` does not
+    consult it at all, so an optional they let attach over a chunk-unmatched `}`
+    is then reported "unclosed `[`" — a diagnostic that blocks the whole file
+    for the formatter, from a brace the macrocode model says is an ordinary
+    token. A gate must mirror the parse it guards, so the fix is in `optional`
+    (skip a `plain_brace` `}` as `element` already does), not in the gates; the
+    in-math gate's unfiltered reading then becomes the odd one out and
+    `PLAIN_BRACES_ARE_TOKENS` can go. Pre-existing, not introduced by C2.5.
 - [ ] **The formatter *and the linter* are superlinear where the parser is
   now linear** (found while measuring C2.2/C2.3, and it is the larger half of
   every "quadratic gate" number this roadmap has been quoting). Two shapes,

--- a/TODO.md
+++ b/TODO.md
@@ -865,13 +865,27 @@ sources below are missing.
   Stages, each gated on the corpus failing-file sets not growing (compare
   sets, not counts):
 
-  - [ ] **C0 — bound the two unbounded gates now**, independent of the map.
-    `delim_math_closes` and `bracket_closes_in_text` have no analogue of the
-    alias gate's bound: a file of `\[` or `\cmd[` openers with no blank line
-    and no closer scans each opener to EOF. Precompute the last-closer
-    positions in the existing `new()` pre-scan (two `usize` fields, the
-    `last_alias_closer` treatment). Cheap, closes the remaining adversarial
-    quadratic shapes today, and survives every later stage.
+  - [x] **C0 — bound every gate by its last-closer index** (done; widened
+    from the two named gates once the survey found a *ninth* scan and a
+    third unbounded one, `bracket_closes_before_math_end`). A gate succeeds
+    only at one closer token shape, so truncating its scan at the last
+    occurrence in the file is verdict-preserving — past it only refusals
+    remain — and a file with none refuses without scanning. Six fields in
+    the `new()` pre-scan, the `last_alias_closer` treatment:
+    `last_r_bracket` (shared by `bracket_closes_in_text` and
+    `bracket_closes_before_math_end`), `last_display_math_closer` and
+    `last_inline_math_closer` (`delim_math_closes`), `last_right`
+    (`left_right_closes`), `last_r_brace` (`environment_escapes_group`),
+    and `last_fi` (`conditional_closer` — this one alone collapses the
+    8000-opener case to ~25ms end-to-end). Scan work is metered
+    (`Parser::scan_work`) and pinned linear by unit tests in `grammar.rs`.
+    Residual superlinear shapes, deferred to the stages below:
+    conditionals whose lone `\fi` sits at EOF (C1's case);
+    `dollar_closes`, where the closer is the opener's own token kind so
+    the bound is vacuous (`${` per line ratchets depth upward and no
+    anchor ever fires); and `environment_escapes_group` in practice,
+    since every `\begin{…}` carries a `}` in its own name group, pushing
+    the bound to EOF.
   - [ ] **C1 — conditionals first.** The gate with the measured pathological
     case and the cleanest policy (its level tracking is already explicit:
     brace, environment, math, macrocode). Build the closer map in the

--- a/TODO.md
+++ b/TODO.md
@@ -995,14 +995,13 @@ sources below are missing.
 
       **Measured, and it corrects the attribution above.** Gate scan work is
       now exactly linear (5 ticks per opener: 2500/5000/10000 at n =
-      500/1000/2000). Parse-side wall clock on the escaping shape (`{`, N
-      `\begin{itemize}`, one `}`) at 2000/4000/8000 went 36/114/407ms →
-      19/20/34ms, quadratic to flat. But `format --check` on the same files
-      only went 79/196/512ms → 46/133/462ms, because **a second quadratic
-      lives downstream in the formatter**: `lint` (lex, parse, lint) is
-      linear at 19/20/34ms while `format --check` is 42/135/455ms on the
-      identical input. The 69/230/984ms figures in the C2 preamble are
-      end-to-end and so were never the gate's alone. New item below.
+      500/1000/2000). Timing `parser::parse` alone on the escaping shape
+      (`{`, N `\begin{itemize}`, one `}`) at 1000/2000/4000: **6.6/25.1/99.3ms
+      → 0.7/1.2/3.5ms**, quadratic to linear, ~28x at n = 4000. The
+      69/230/984ms figures in the C2 preamble are `format --check` end to end
+      and were never the gate's alone; nor is `badness lint` a stand-in for
+      the parser, since it runs every linter rule. Measure `parse` directly
+      when judging a parser change. New item below for the rest.
     - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
       environments at *any* brace depth, unlike the conditional and `\begin`
       gates: a driver knob, an explicit divergence. `dollar` is the
@@ -1054,16 +1053,21 @@ sources below are missing.
     stepping stone to the map; C2.0 keeps that order by *extracting* the
     driver from C1's working batch rather than authoring a
     lowest-common-denominator scan.
-- [ ] **The formatter is superlinear in a group's child count** (found while
-  measuring C2.2, and it is the *other* half of every "quadratic gate" number
-  recorded above). On `{`, N `\begin{itemize}`, `}` — one brace group with N
-  demoted commands in it — `badness lint` (lex, parse, lint) is flat at
-  19/20/34ms for N = 2000/4000/8000 while `badness format --check` on the same
-  files is 42/135/455ms, growing ~3.4x per doubling. The parser is no longer
-  implicated, so it is lowering or printing. Profile it (`task bench:profile`
-  takes `BADNESS_BENCH_DOC`) before guessing; the shape is degenerate, but a
-  real `.sty` with a few thousand siblings in one group is not far off, and the
-  gate work this roadmap has been shaving is now the smaller term.
+- [ ] **The formatter *and the linter* are superlinear where the parser is
+  now linear** (found while measuring C2.2/C2.3, and it is the larger half of
+  every "quadratic gate" number this roadmap has been quoting). Two shapes,
+  with `parse` timed directly against the CLI on the same input:
+  - `{`, N `\begin{itemize}`, `}` at N = 4000: `parse` 3.5ms,
+    `format --check` 133ms.
+  - N `\[` with one `\]` at EOF at N = 4000: `parse` **0.4ms**, `lint`
+    **287ms** (93ms at N = 2000, so ~3.1x per doubling).
+
+  The parser is no longer implicated in either. The second one is the louder
+  finding: a linter rule is quadratic on math-delimiter-heavy input. Profile
+  before guessing (`task bench:profile` takes `BADNESS_BENCH_DOC`). The shapes
+  are degenerate, but the gate work this roadmap has been shaving is now the
+  smaller term by two orders of magnitude, which is worth knowing before
+  spending more on C2.
 - [ ] **Fuzz/property losslessness harness — the one missing oracle layer.**
   Everything today is curated corpus + snapshots; nothing exercises
   `PARSER_STEP_LIMIT` or the recovery paths with arbitrary bytes, and

--- a/TODO.md
+++ b/TODO.md
@@ -824,8 +824,12 @@ sources below are missing.
     line is a comment, not a docstrip guard, so the extracted file changes — a
     meaning change, not a cosmetic one. Every `.dtx` in the list is this shape.
     Likely the same margin/guard column-0 pinning the reflow already backstops.
-- [ ] **Replace the per-opener gate scans with a precomputed closer map
-  (container stack; multi-session).** Every shape gate today runs one forward
+- [~] **Replace the per-opener gate scans with a precomputed closer map
+  (container stack; multi-session).** *Closed at C3 with three of the six
+  gates migrated — conditionals, aliases, and the `\begin` brace-escape gate
+  all run the shared batch driver; the math and bracket gates keep their own
+  scans, on measurement rather than on difficulty (C2.3–C2.5, C3).* Every
+  shape gate today runs one forward
   token scan per live opener, each a hand transcription of the same
   bookkeeping — brace depth with `plain_braces`, `\begin`/`\end` counting,
   blank-line runs, the macrocode bound — eight copies in `grammar.rs`, growing
@@ -1002,28 +1006,40 @@ sources below are missing.
       and were never the gate's alone; nor is `badness lint` a stand-in for
       the parser, since it runs every linter rule. Measure `parse` directly
       when judging a parser change. New item below for the rest.
-    - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
-      environments at *any* brace depth, unlike the conditional and `\begin`
-      gates: a driver knob, an explicit divergence. `dollar` is the
-      interesting one — its closer is its own opener's token kind, so entries
-      chain (each depth-0 `$` settles the previous entry and pushes itself)
-      and `display` becomes per-entry state. This is what finally kills the
-      `${`-per-line shape C0 recorded as unreachable by bounding.
-    - [ ] **C2.4 — `left_right_closes`.** A third environment-counting mode: a
-      brace group is opaque, skipped wholesale. Also the one gate whose
+    - [ ] **C2.3–C2.5 — the math and bracket family: parked, deliberately**
+      (decision taken after C2.2, and it is C3's decision arriving early).
+      Measuring `parse` directly voided the perf premise for the whole
+      family:
+      - `delim_math_closes` — N `\[` with one `\]` at EOF, at 1000/2000/4000:
+        **0.1/0.2/0.4ms**. Already linear; a batch has nothing to fix.
+      - `dollar_closes` — the `${`-per-line shape C0 recorded: 3.8/13.9/53.8ms,
+        quadratic, and **a batch provably cannot help it**. After the first
+        `${` the brace depth ratchets upward and never returns to 0, so no
+        later opener sits at depth 0 in the seed's scan: the batch settles its
+        seed alone and every opener re-batches. That shape wants the *map* (a
+        per-frame "next `$` at the same brace depth"), the design C1 abandoned
+        as un-precomputable from walk state.
+
+      What was left was consolidation at the price of roughly three more
+      policy knobs (an unconditional `StrayBrace::Refutes`, environments
+      counted at any brace depth, no env balance required at the closer),
+      taking the driver to six — a policy interpreter, on gates with no
+      measured problem. Against that, the same measurement found the linter
+      and formatter two orders of magnitude more expensive on the identical
+      inputs (item below), so the effort goes there.
+
+      **If this is picked back up**, the notes that were already worked out:
+      `left_right_closes` needs a third environment-counting mode (a brace
+      group is opaque, skipped wholesale) and is the one gate whose
       opener/closer recognition deliberately ignores `in_macro_code` (issue
-      \#95) — the fix that lives in exactly one copy today, and the concrete
-      payoff of consolidating.
-    - [ ] **C2.5 — the bracket family** (`bracket_closes_in_text`,
-      `bracket_closes_before_math_end`,
-      `bracket_closes_before_macrocode_end`). The `abuts_command` claim
-      countdown *is* the driver's nested-opener stack once an "opener" is
-      defined as a command-abutting `[`. Two things to settle first:
-      `bracket_closes_before_math_end` must carry `math_dollar.last()` in its
-      memo key, and it is the only bracket gate that does **not** filter
-      `plain_braces` on `L_BRACE`/`R_BRACE` — decide whether that is
-      deliberate or a latent macrocode bug before preserving it into the
-      driver.
+      \#95) — the fix that still lives in exactly one copy, and the standing
+      argument for consolidating some day. In the bracket family, the
+      `abuts_command` claim countdown *is* the driver's nested-opener stack
+      once an "opener" is a command-abutting `[`;
+      `bracket_closes_before_math_end` would need `math_dollar.last()` in its
+      key, and it is the only bracket gate that does **not** filter
+      `plain_braces` on `L_BRACE`/`R_BRACE` — worth deciding whether that is
+      deliberate or a latent macrocode bug regardless of this item.
 
     **Migration technique**, per stage: keep the old per-opener scan as a
     `#[cfg(debug_assertions)]` reference and assert `batch(open) ==
@@ -1041,18 +1057,16 @@ sources below are missing.
     scan-work test per gate, on the shapes measured above; and `task
     bench:micro` flat on real documents, so a memo miss never costs the common
     case.
-  - [ ] **C3 — decide whether to finish.** Cheaper to decide once C2.0 has
-    landed: with the gates on one driver the question is whether any gate
-    stays on single-verdict runs, not whether to build a fallback. If the
-    math-gate restatement proves too entangled, stopping with conditionals and
-    aliases batched and the math/bracket gates running the same driver one
-    opener at a time — the bound, the brace/env/blank-line bookkeeping, and
-    the macrocode-frame refusal shared, the batch stack unused — is a
-    respectable end-state: the skeleton and the map are two depths of the same
-    consolidation, chosen per gate. Do **not** build the skeleton first as a
-    stepping stone to the map; C2.0 keeps that order by *extracting* the
-    driver from C1's working batch rather than authoring a
-    lowest-common-denominator scan.
+  - [x] **C3 — decide whether to finish** (decided: stop at three gates).
+    Conditionals, aliases, and the `\begin` brace-escape gate are batched on
+    the shared driver; the math and bracket gates keep their explicit scans,
+    for the reasons in C2.3–C2.5 above. The end-state the item allowed for —
+    part of the family on the map, part on its own scans, chosen per gate —
+    is the one we took, and it was chosen on measurement rather than on the
+    entanglement the item anticipated: the math gates are not too hard to
+    restate, they simply have nothing left to gain. The consolidation
+    argument (one copy of the bookkeeping, so a fix propagates) survives this
+    decision and is the reason to revisit if a drift bug like #95 recurs.
 - [ ] **The formatter *and the linter* are superlinear where the parser is
   now linear** (found while measuring C2.2/C2.3, and it is the larger half of
   every "quadratic gate" number this roadmap has been quoting). Two shapes,

--- a/TODO.md
+++ b/TODO.md
@@ -916,7 +916,7 @@ sources below are missing.
     one linear pass (~34ms for 8000 openers end-to-end), pinned by
     `conditional_batch_keeps_shared_frame_openers_linear`.
   - [x] **C2 — migrate the remaining gates onto one batch driver** (done in
-    five stages, C2.1–C2.5; all eight gates now run on `Parser::gate_batch`),
+    five stages, C2.1–C2.5; all nine gates now run on `Parser::gate_batch`),
     easiest policy first: alias, then `environment_escapes_group`, then the
     math and bracket family. This item's original wording ("each migration deletes one
     transcribed scan and its copy of the bookkeeping") belongs to the

--- a/TODO.md
+++ b/TODO.md
@@ -1026,6 +1026,12 @@ sources below are missing.
       more expensive on the same inputs anyway (item below), and that is where
       speed work belongs.
 
+      *(Amended by C2.4, which was never measured here: the two gates above are
+      single-entry, so a batch has nothing to settle beyond its seed, but
+      `left_right_closes` nests densely and did go quadratic to linear, ~36x at
+      n = 4000. "The perf case for what remains is void" holds for the shapes
+      measured, not for the stages.)*
+
     - [x] **C2.3 — `delim_math_closes`, then `dollar_closes`** (done).
       `DelimMathGate` and `DollarGate` are both **single-entry** as planned
       (`opens_at` always false), and the plan's knobs all landed:
@@ -1083,11 +1089,64 @@ sources below are missing.
       (38.6 → 35.9 ms end to end at n = 4000, the new bound if anything
       helping), and stays quadratic by design — the test says so rather than
       pinning a shape the gate cannot fix.
-    - [ ] **C2.4 — `left_right_closes`.** A third environment-counting mode: a
-      brace group is opaque, skipped wholesale. Also the one gate whose
-      opener/closer recognition deliberately ignores `in_macro_code` (issue
-      \#95) — the fix that lives in exactly one copy today, and the concrete
-      payoff of consolidating.
+    - [x] **C2.4 — `left_right_closes`** (done). The `in_macro_code` blind spot
+      (issue \#95) is now two policy predicates (`opens_at`/`closes_at`) beside
+      the driver's own `\begin`/`\end` filter, which is the consolidation this
+      item promised. The predicted "third environment-counting mode" was **not**
+      one: a brace group is already opaque in the driver, since every arm but
+      the brace arms is gated on `depth == 0` and `ENVS_AT_ANY_DEPTH` is false.
+      What the gate actually diverges on is *nesting shape*, and it is worth
+      more than the brace point:
+
+      - **`Nesting::Interleaved`, the driver's second nesting model.** Every
+        other gate counts nested openers and environments as two independent
+        tallies, because that is all its per-opener scan knew. This one's scan
+        is a single LIFO stack of `{`, `\begin`, and `\left` frames — a pair
+        closes by count wherever it sits — and the two halves of that read
+        differently. A frame **mismatch** (an `\end` or a `\right` meeting a
+        frame of the wrong kind) refuses *every* live entry, since the innermost
+        frame is the same one for all of them; the **absence** of frames that
+        the blank-line anchor tests is seen only by the innermost entry, so a
+        nested pair *shields* the ones around it and the anchor settles one
+        entry, not a level. Both are pinned
+        (`an_end_inside_a_nested_left_refuses_the_whole_scan`,
+        `a_nested_left_shields_the_outer_pair_from_a_paragraph_break`).
+      - **`MathAnchor`, replacing `MATH_REFUTES`.** The old boolean could not
+        say what this gate needs: it anchors on `$`/`\]`/`\)`, the *closing*
+        side, where the pairing gates anchor on `$`/`\[`/`\(`. Which side
+        follows from where the construct lives — a conditional lives in text and
+        is defeated by math starting, a `\left` lives inside math and is
+        defeated by that math ending, and those are exactly `left_right`'s own
+        recovery anchors. `None`/`Opening`/`Closing`, one arm each.
+      - **A gate/walk looseness surfaced, not introduced.** In the shielded
+        shape the gate says the outer pair closes while `left_right` bails at
+        the paragraph break and reports it unclosed. It predates the migration
+        (the per-opener scan's `stack.is_empty()` behaved identically) and C2
+        migrates verdicts unchanged, so it is preserved and pinned rather than
+        fixed. Reachable only inside a math *environment*, since the `$`/`\[`
+        gates refuse a blank line themselves. Fixing it is its own commit
+        against the "a shape gate must mirror the parse it guards" rule.
+
+      **Measured** (`parse` alone via `bench:micro`, N `\left(` in one `$…$`
+      with a single `\right)` at the end, 1000/2000/4000): **3.9/14.6/57.0ms →
+      0.39/1.0/1.6ms**, quadratic to linear, ~36x at n = 4000. Unlike C2.3's
+      single-entry gates this one had real work to save: a `\left` the walk
+      demotes is retried as a plain command and every `\left` after it is asked
+      in turn, so a run of them re-scanned per opener. Pinned by
+      `left_right_batch_keeps_shared_frame_openers_linear`. `bench:micro` on the
+      four real documents is flat within run-to-run noise.
+
+      Shadow differential green: the suite, a per-file debug-assertions pass
+      over all 6277 corpus files, and a `.tex`/`.dtx` torture pair. The torture
+      files discriminate all four of the gate's policy knobs — flipping
+      `MATH_ANCHOR`, `NESTING`, `MACROCODE_FRAME_ANCHORS`, or `STRAY_BRACE`
+      panics on them — which is the bar a torture file should meet; the
+      stray-brace shape needed a `\left` inside a math *environment*, since a
+      stray `}` demotes an enclosing `$` before the gate is ever asked. Two
+      process notes: the driver's `break` paths must not leave an index in
+      `live` pointing past `pending` (the interleaved closer arm pops its entry
+      first, and the corpus pass caught the panic at once), and the reference
+      copy must not tick `scan_work` or it hides the linearity the pin measures.
     - [ ] **C2.5 — the bracket family** (`bracket_closes_in_text`,
       `bracket_closes_before_math_end`,
       `bracket_closes_before_macrocode_end`). The `abuts_command` claim

--- a/TODO.md
+++ b/TODO.md
@@ -934,28 +934,28 @@ sources below are missing.
     on its own shape, and alias needs both halves defined in the same file, so
     those two are migrated for uniformity rather than for speed.
 
-    - [ ] **C2.0 — extract the batch driver; re-express conditionals on it.**
-      Lift `conditional_closers_from`'s engine into a reusable scan owning
+    - [x] **C2.0 — extract the batch driver; re-express conditionals on it**
+      (done). `conditional_closers_from` became `Parser::gate_batch`, owning
       only the *bookkeeping*: the bound (`macrocode_end` ∧ `tokens.len()` ∧
       last closer + 1), trivia skip, newline runs, brace depth under
       `plain_braces`, environment counting with the `macrocode`-frame break in
       both directions, the `group_depth > 0` stray-`}` rule, the
-      `pending`/`live` stack with `envs_at_push`, settled-never-popped,
-      `tick_scan` metering, and the walk-state memo. Per-gate policy stays an
-      explicit struct of named hooks (`is_opener`, `closer_at`,
-      `paragraph_anchors`, `env_counting`, `on_math`, `eof_verdict`), each
-      keeping the doc comment it carries today: the driver owns the
-      bookkeeping and never averages the policies. No behavior change; the
-      existing conditional tests pin it. This is not the C3 skeleton built
-      first — the driver is *extracted from C1's working batch*, so the map
-      stays the foundation and C3 becomes a subtraction rather than a
-      construction. Two fixes belong in the extraction: give `plain_braces` a
-      version counter bumped in `macrocode_body` so the memo key is a fact
-      instead of the current "pinned by the frame" argument, and hoist
-      **settled-never-popped** into the driver, since every remaining gate has
-      the same never-un-counted nested-opener countdown (`nested` for alias,
-      `brackets` for the bracket pair, the `Ctx::Left` stack for `\left`) and
-      every new policy must answer for it explicitly.
+      `pending`/`live` stack with `envs_at_push`, settled-never-popped, and
+      `tick_scan` metering. `gated_closer` is the memoized front and holds the
+      C0 early-out; `WalkKey` is the memo key, with `plain_braces` now riding a
+      version counter bumped in `macrocode_body` so the key is a fact rather
+      than the old "pinned by the frame" argument. Per-gate policy is the
+      `GatePolicy` trait — `PARAGRAPH_ANCHOR`, `last_closer`, `opens_at`,
+      `closes_at`, and a defaulted `pairs` — with `ConditionalGate` its first
+      client; hooks arrive with the client that needs them, so the trait says
+      only what a real gate has asked for. The driver never averages the
+      policies. Not the C3 skeleton built first: it is *extracted from C1's
+      working batch*, so the map stays the foundation and C3 becomes a
+      subtraction. Verdict-preserving, as the acceptance gate below demands —
+      the suite, all eight gate-corpora baselines, and the texlab
+      parse-compat report are unchanged, and `bench:micro` is flat within
+      run-to-run noise (parse-only spread on the small documents is ±30%
+      between runs either way).
     - [ ] **C2.1 — alias.** Conditional's policy minus the paragraph anchor,
       plus the named-closer test (`closing == target`); retires
       `alias_closer_memo` into the shared memo. Low value, low risk: its job

--- a/TODO.md
+++ b/TODO.md
@@ -825,11 +825,11 @@ sources below are missing.
     meaning change, not a cosmetic one. Every `.dtx` in the list is this shape.
     Likely the same margin/guard column-0 pinning the reflow already backstops.
 - [~] **Replace the per-opener gate scans with a precomputed closer map
-  (container stack; multi-session).** *Closed at C3 with three of the six
-  gates migrated — conditionals, aliases, and the `\begin` brace-escape gate
-  all run the shared batch driver; the math and bracket gates keep their own
-  scans, on measurement rather than on difficulty (C2.3–C2.5, C3).* Every
-  shape gate today runs one forward
+  (container stack; multi-session).** *Three of six gates migrated so far —
+  conditionals, aliases, and the `\begin` brace-escape gate run the shared
+  batch driver; the math and bracket family is C2.3–C2.5, to be finished for
+  **uniformity**, since measurement has since voided the perf case for those
+  three (see C2.3).* Every shape gate today runs one forward
   token scan per live opener, each a hand transcription of the same
   bookkeeping — brace depth with `plain_braces`, `\begin`/`\end` counting,
   blank-line runs, the macrocode bound — eight copies in `grammar.rs`, growing
@@ -1006,40 +1006,64 @@ sources below are missing.
       and were never the gate's alone; nor is `badness lint` a stand-in for
       the parser, since it runs every linter rule. Measure `parse` directly
       when judging a parser change. New item below for the rest.
-    - [ ] **C2.3–C2.5 — the math and bracket family: parked, deliberately**
-      (decision taken after C2.2, and it is C3's decision arriving early).
-      Measuring `parse` directly voided the perf premise for the whole
-      family:
-      - `delim_math_closes` — N `\[` with one `\]` at EOF, at 1000/2000/4000:
-        **0.1/0.2/0.4ms**. Already linear; a batch has nothing to fix.
-      - `dollar_closes` — the `${`-per-line shape C0 recorded: 3.8/13.9/53.8ms,
-        quadratic, and **a batch provably cannot help it**. After the first
-        `${` the brace depth ratchets upward and never returns to 0, so no
-        later opener sits at depth 0 in the seed's scan: the batch settles its
-        seed alone and every opener re-batches. That shape wants the *map* (a
-        per-frame "next `$` at the same brace depth"), the design C1 abandoned
-        as un-precomputable from walk state.
+      **The perf case for what remains is void — finish it for uniformity.**
+      Measuring `parse` directly (1000/2000/4000 openers) after C2.2:
+      - `delim_math_closes`, N `\[` with one `\]` at EOF: **0.1/0.2/0.4ms**.
+        Already linear; a batch has nothing to fix there.
+      - `dollar_closes`, the `${`-per-line shape C0 recorded:
+        **3.8/13.9/53.8ms**, quadratic — and **a batch cannot help it**. After
+        the first `${` the brace depth ratchets upward and never returns to 0,
+        so no later opener sits at depth 0 in the seed's scan: the batch
+        settles its seed alone and every opener re-batches. Killing that shape
+        needs the *map* (a per-frame "next `$` at the same brace depth"), the
+        design C1 abandoned as un-precomputable from walk state — so do not
+        repeat C0's claim that batching reaches it.
 
-      What was left was consolidation at the price of roughly three more
-      policy knobs (an unconditional `StrayBrace::Refutes`, environments
-      counted at any brace depth, no env balance required at the closer),
-      taking the driver to six — a policy interpreter, on gates with no
-      measured problem. Against that, the same measurement found the linter
-      and formatter two orders of magnitude more expensive on the identical
-      inputs (item below), so the effort goes there.
+      So C2.3–C2.5 are a **structural** change, deliberately: one driver, one
+      copy of the bookkeeping, every gate's divergence stated as a named
+      policy instead of a hand-transcribed scan. Judge them on the code, not
+      on a benchmark; the linter and formatter are two orders of magnitude
+      more expensive on the same inputs anyway (item below), and that is where
+      speed work belongs.
 
-      **If this is picked back up**, the notes that were already worked out:
-      `left_right_closes` needs a third environment-counting mode (a brace
-      group is opaque, skipped wholesale) and is the one gate whose
+    - [ ] **C2.3 — `delim_math_closes`, then `dollar_closes`.** Both count
+      environments at *any* brace depth, unlike the conditional and `\begin`
+      gates, and neither requires an environment balance at the closer — two
+      driver knobs, both explicit divergences. Their stray-`}` refusal is
+      unconditional where the positive gates' is `group_depth`-gated, so
+      `StrayBrace` grows a third variant. Neither treats a foreign math
+      delimiter as an anchor (`MATH_REFUTES = false`, as `EnvGate` already
+      sets). `dollar` adds two wrinkles: its closer is its own opener's token
+      kind, and a display `$$` opener starts the scan two tokens along — pass
+      the seed as `open + 1` from the caller rather than adding a hook, and
+      give `DollarGate` a `display` field for the "next token is `$`" test.
+      Run both **single-entry** (`opens_at` always false): their openers do
+      not nest — the first depth-0 closer answers every live opener at once —
+      so there is no LIFO to model and no closer-scope hook to add. `dollar`
+      also wants a `last_dollar` bound recorded in `new()` to keep the
+      `last_closer` contract honest.
+    - [ ] **C2.4 — `left_right_closes`.** A third environment-counting mode: a
+      brace group is opaque, skipped wholesale. Also the one gate whose
       opener/closer recognition deliberately ignores `in_macro_code` (issue
-      \#95) — the fix that still lives in exactly one copy, and the standing
-      argument for consolidating some day. In the bracket family, the
-      `abuts_command` claim countdown *is* the driver's nested-opener stack
-      once an "opener" is a command-abutting `[`;
-      `bracket_closes_before_math_end` would need `math_dollar.last()` in its
-      key, and it is the only bracket gate that does **not** filter
-      `plain_braces` on `L_BRACE`/`R_BRACE` — worth deciding whether that is
-      deliberate or a latent macrocode bug regardless of this item.
+      \#95) — the fix that lives in exactly one copy today, and the concrete
+      payoff of consolidating.
+    - [ ] **C2.5 — the bracket family** (`bracket_closes_in_text`,
+      `bracket_closes_before_math_end`,
+      `bracket_closes_before_macrocode_end`). The `abuts_command` claim
+      countdown *is* the driver's nested-opener stack once an "opener" is
+      defined as a command-abutting `[`. Two things to settle first:
+      `bracket_closes_before_math_end` must carry `math_dollar.last()` in its
+      memo key, and it is the only bracket gate that does **not** filter
+      `plain_braces` on `L_BRACE`/`R_BRACE` — decide whether that is
+      deliberate or a latent macrocode bug before preserving it into the
+      driver.
+
+      One driver change these three share, and it is a *simplification*: ask
+      `opens_at`/`closes_at` for any non-trivia token at the entries' own
+      level instead of only for a `CONTROL_WORD`, since these gates' closers
+      are `DOLLAR`, `CONTROL_SYMBOL`, and `R_BRACKET`. The existing three
+      policies already test the token kind inside their own predicates, so
+      widening costs them nothing.
 
     **Migration technique**, per stage: keep the old per-opener scan as a
     `#[cfg(debug_assertions)]` reference and assert `batch(open) ==
@@ -1057,16 +1081,15 @@ sources below are missing.
     scan-work test per gate, on the shapes measured above; and `task
     bench:micro` flat on real documents, so a memo miss never costs the common
     case.
-  - [x] **C3 — decide whether to finish** (decided: stop at three gates).
-    Conditionals, aliases, and the `\begin` brace-escape gate are batched on
-    the shared driver; the math and bracket gates keep their explicit scans,
-    for the reasons in C2.3–C2.5 above. The end-state the item allowed for —
-    part of the family on the map, part on its own scans, chosen per gate —
-    is the one we took, and it was chosen on measurement rather than on the
-    entanglement the item anticipated: the math gates are not too hard to
-    restate, they simply have nothing left to gain. The consolidation
-    argument (one copy of the bookkeeping, so a fix propagates) survives this
-    decision and is the reason to revisit if a drift bug like #95 recurs.
+  - [x] **C3 — decide whether to finish** (decided: **finish it**). The
+    fallback this stage exists to authorize — part of the family on the map,
+    part on its own scans — is *not* taken. The measurement that closed the
+    perf case (C2.3) did not make the math gates hard to restate; it only made
+    them unrewarding to benchmark, and the item's original complaint was never
+    really about speed: it was eight hand transcriptions of one piece of
+    bookkeeping, where a fix to one copy does not propagate (#95). One driver
+    with named per-gate policies is the end-state. Revisit only if a gate's
+    policy genuinely cannot be stated without averaging it against another's.
 - [ ] **The formatter *and the linter* are superlinear where the parser is
   now linear** (found while measuring C2.2/C2.3, and it is the larger half of
   every "quadratic gate" number this roadmap has been quoting). Two shapes,

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -278,8 +278,73 @@ enum StrayBrace {
     /// [`Parser::dollar_math`] and [`Parser::delim_math`], which bail at *any*
     /// unbalanced `}` — for them the brace is a recovery anchor of the parse
     /// itself, not merely a group boundary — and a gate must mirror the parse
-    /// it guards.
+    /// it guards. [`LeftRightGate`] joins them: [`Parser::left_right`] bails at
+    /// any unbalanced `}` too.
     RefutesAlways,
+}
+
+/// Which math delimiters anchor a gate's scan at the entries' own level.
+///
+/// Which side anchors follows from where the gated construct *lives*. A
+/// conditional or an alias lives in text, so what defeats it is math
+/// **starting**: the scan does not model the `$`/`\[`/`\(` shape gates, and a
+/// closer behind a delimiter that opens math may well be swallowed by it. A
+/// `\left…\right` pair already lives *inside* math, so what defeats it is the
+/// enclosing math **ending** — exactly [`Parser::left_right`]'s own recovery
+/// anchors. A `$` is both, and anchors either way.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MathAnchor {
+    /// Nothing anchors: a foreign delimiter is ordinary content. The demotion
+    /// gate reads it this way because refusing there would *keep* a construct
+    /// the scan cannot vouch for, and for the math gates the delimiter is the
+    /// closer itself.
+    None,
+    /// `$`, `\[`, `\(` — math starting.
+    Opening,
+    /// `$`, `\]`, `\)` — math ending.
+    Closing,
+}
+
+impl MathAnchor {
+    /// Whether the control symbol `text` anchors under this policy. `$` is
+    /// handled by the driver's own [`SyntaxKind::DOLLAR`] arm, since it is both
+    /// an opener and a closer.
+    fn anchors(self, text: &str) -> bool {
+        match self {
+            MathAnchor::None => false,
+            MathAnchor::Opening => matches!(text, "\\[" | "\\("),
+            MathAnchor::Closing => matches!(text, "\\]" | "\\)"),
+        }
+    }
+}
+
+/// How a gate's nested entries relate to the `\begin`-opened environments
+/// between them — the shape of the model its per-opener scan used, which the
+/// batch must reproduce exactly.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Nesting {
+    /// Two independent counters. A nested opener is counted *by name* and never
+    /// un-counted, environments are counted separately, and an anchor settles
+    /// every entry standing at its own environment level. This is what the
+    /// pairing gates' per-opener scans did: they never modelled the order in
+    /// which a nested opener and an environment were opened, only how many of
+    /// each stood between an entry and the token at hand.
+    Counted,
+    /// One LIFO stack, entries and environments interleaved.
+    /// [`Parser::left_right_closes`] tracks its nesting this way because
+    /// [`Parser::left_right`] does: a pair is closed by *count* wherever it
+    /// sits, so its scan pushes a frame per `\left`, per `\begin`, and per `{`
+    /// alike, and any frame **mismatch** — an `\end` or a `\right` reaching a
+    /// frame of the wrong kind — refuses outright.
+    ///
+    /// Two consequences the driver must honor, both following from *whose*
+    /// frame is innermost. A mismatch is seen by every outer entry too, since
+    /// the innermost frame is common to all of them, so it refutes the whole
+    /// scan rather than one level of it. An *absence* of frames, on the other
+    /// hand — the blank-line anchor's `stack.is_empty()` — is seen only by the
+    /// entry that owns the innermost frame, so a nested entry **shields** the
+    /// entries below it from a paragraph break.
+    Interleaved,
 }
 
 /// The per-gate half of [`Parser::gate_batch`]: how far this gate's scan can
@@ -308,15 +373,17 @@ trait GatePolicy {
     /// *positive* gates' reading; see [`StrayBrace`].
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesInGroup;
 
-    /// Whether a math delimiter at the entries' own level refutes them.
+    /// Which math delimiters at the entries' own level refute them, if any.
     ///
-    /// True for the positive gates: the scan does not model the `$`/`\[`/`\(`
-    /// shape gates, and declining to pair behind one is the conservative
-    /// direction for a construct that only pairs when positively located. A
-    /// *demotion* gate inverts that — refusing there would keep a construct the
-    /// scan cannot vouch for — so `EnvGate` sets this false and reads math as
-    /// ordinary content, exactly as its pre-batch scan did.
-    const MATH_REFUTES: bool = true;
+    /// Defaults to the text-dwelling positive gates' reading — math *starting*
+    /// refutes, the conservative direction for a construct that only pairs when
+    /// positively located. See [`MathAnchor`] for the other two.
+    const MATH_ANCHOR: MathAnchor = MathAnchor::Opening;
+
+    /// How this gate's nested entries interleave with the environments between
+    /// them. See [`Nesting`]; the pairing and math gates all count, only
+    /// [`LeftRightGate`] stacks.
+    const NESTING: Nesting = Nesting::Counted;
 
     /// Whether this gate's openers are themselves `\begin`s, so the driver must
     /// count one in `envs` *before* pushing its entry. An entry's `envs_at_push`
@@ -447,7 +514,7 @@ impl GatePolicy for AliasGate {
 ///
 /// - **The stray `}` closes rather than refutes** ([`StrayBrace::ClosesInGroup`]).
 ///   Same token event, opposite verdict.
-/// - **Math does not refuse** ([`GatePolicy::MATH_REFUTES`]). For a positive
+/// - **Math does not refuse** ([`MathAnchor::None`]). For a positive
 ///   gate, declining behind a math delimiter is the conservative direction; for
 ///   this one it would *keep* an environment the scan cannot vouch for. The
 ///   pre-batch scan had no math anchor, and this preserves that.
@@ -465,7 +532,7 @@ struct EnvGate;
 impl GatePolicy for EnvGate {
     const PARAGRAPH_ANCHOR: bool = false;
     const STRAY_BRACE: StrayBrace = StrayBrace::ClosesInGroup;
-    const MATH_REFUTES: bool = false;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::None;
     const OPENER_IS_ENV_BEGIN: bool = true;
 
     fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
@@ -499,7 +566,7 @@ impl GatePolicy for EnvGate {
 ///
 /// - **A `}` refutes unconditionally** ([`StrayBrace::RefutesAlways`]): the
 ///   guarded parses bail at any unbalanced `}`, group behind it or not.
-/// - **Math is not an anchor** ([`GatePolicy::MATH_REFUTES`]) — a foreign
+/// - **Math is not an anchor** ([`MathAnchor::None`]) — a foreign
 ///   delimiter is ordinary content here, and for [`DollarGate`] the delimiter
 ///   *is* the closer.
 /// - **Environments count at any depth** ([`GatePolicy::ENVS_AT_ANY_DEPTH`]).
@@ -521,7 +588,7 @@ struct DelimMathGate {
 impl GatePolicy for DelimMathGate {
     const PARAGRAPH_ANCHOR: bool = true;
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
-    const MATH_REFUTES: bool = false;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::None;
     const ENVS_AT_ANY_DEPTH: bool = true;
     const CLOSER_NEEDS_ENV_BALANCE: bool = false;
     const MACROCODE_FRAME_ANCHORS: bool = false;
@@ -564,7 +631,7 @@ struct DollarGate {
 impl GatePolicy for DollarGate {
     const PARAGRAPH_ANCHOR: bool = true;
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
-    const MATH_REFUTES: bool = false;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::None;
     const ENVS_AT_ANY_DEPTH: bool = true;
     const CLOSER_NEEDS_ENV_BALANCE: bool = false;
     const MACROCODE_FRAME_ANCHORS: bool = false;
@@ -584,6 +651,67 @@ impl GatePolicy for DollarGate {
     fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
         p.tokens[i].kind == SyntaxKind::DOLLAR
             && (!self.display || p.tokens.get(i + 1).map(|t| t.kind) == Some(SyntaxKind::DOLLAR))
+    }
+}
+
+/// [`Parser::left_right_closes`]'s policy: a `\left` paired with the `\right`
+/// that [`Parser::left_right`] would reach. The gate that lives *inside* math,
+/// and the only one whose entries stack rather than count
+/// ([`Nesting::Interleaved`]) — `\left`/`\right` pair by count wherever they
+/// sit, so its scan reads one frame stack of `{`, `\begin`, and `\left` alike,
+/// and any mismatch refuses.
+///
+/// The other three divergences follow from the same two facts:
+///
+/// - **Math *ending* anchors** ([`MathAnchor::Closing`]). A `\left` sits inside
+///   a math body already, so `$`, `\]`, `\)` are the tokens that end it —
+///   [`Parser::left_right`]'s own recovery anchors — while a `\[` in the way is
+///   ordinary content.
+/// - **A `}` refutes unconditionally** ([`StrayBrace::RefutesAlways`]), for the
+///   same reason as the math gates: the parse it guards bails at any unbalanced
+///   `}`, group behind it or not.
+/// - **A `macrocode` frame is not an anchor**
+///   ([`GatePolicy::MACROCODE_FRAME_ANCHORS`]), preserved from the pre-batch
+///   scan, which counted `\begin{macrocode}` as an ordinary environment — the
+///   reading the math gates keep too.
+///
+/// And the one thing this migration exists to consolidate: **`\left`/`\right`
+/// recognition ignores `in_macro_code` on purpose** where the driver's own
+/// `\begin`/`\end` counting does not. They are catcode-neutral math structure
+/// that pairs by count no matter what, and [`Parser::left_right`] consumes them
+/// unconditionally, so a definition body or a `macrocode` chunk — exactly where
+/// package math like `$\left#2\right#4$` (delarray.dtx) or `$\left(…\right)$`
+/// (ltmath.dtx's `\bordermatrix`) lives — must still be scanned for them.
+/// Gating them out left the `\right` invisible, so the pair never opened and the
+/// closer reported a spurious "`\right` without matching `\left`" that blocked
+/// the whole file for the formatter (issue #95). As a policy that is two
+/// predicates; as a hand-written scan it was a comment nothing enforced.
+struct LeftRightGate;
+
+impl GatePolicy for LeftRightGate {
+    const PARAGRAPH_ANCHOR: bool = true;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::Closing;
+    const NESTING: Nesting = Nesting::Interleaved;
+    const MACROCODE_FRAME_ANCHORS: bool = false;
+
+    /// The last `\right` in the file. The recording ignores brace nesting, which
+    /// only ever places the bound *past* the last viable closer. Without it a
+    /// math body of `\left` openers with no `\right` kept the frame stack
+    /// non-empty — so the blank-line anchor never fired — and scanned each opener
+    /// to the math's end.
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_right
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        let t = &p.tokens[i];
+        t.kind == SyntaxKind::CONTROL_WORD && t.text.as_str() == LEFT_CMD
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        let t = &p.tokens[i];
+        t.kind == SyntaxKind::CONTROL_WORD && t.text.as_str() == RIGHT_CMD
     }
 }
 
@@ -781,6 +909,11 @@ struct Parser<'t> {
     /// settled its neighbors this slot was load-bearing: without it every
     /// opener paid for its walk twice.
     alias_batch: std::cell::RefCell<Option<GateBatch>>,
+    /// The [`LeftRightGate`] twin of [`Self::conditional_batch`]. Its openers
+    /// nest densely — a `\left` whose `\right` the walk cannot reach is retried
+    /// as a plain command and every `\left` after it asked in turn — so the
+    /// batch is what keeps a run of them from being quadratic.
+    left_right_batch: std::cell::RefCell<Option<GateBatch>>,
     /// Token index of the alias closer bounding the environment body currently
     /// being parsed, if any. Saved and restored around the body in
     /// [`Self::alias_environment`]. An alias environment has no `\end{…}` to stop
@@ -933,6 +1066,7 @@ impl<'t> Parser<'t> {
             alias_closers,
             alias_batch: std::cell::RefCell::new(None),
             env_batch: std::cell::RefCell::new(None),
+            left_right_batch: std::cell::RefCell::new(None),
             alias_end: None,
         }
     }
@@ -2221,109 +2355,13 @@ impl<'t> Parser<'t> {
     /// not owed to an intervening `\begin`, a paragraph break, EOF — with `\right`
     /// and the anchors counting only at the `\left`'s own brace/env/pair level.
     /// Does not consume.
+    ///
+    /// Runs on the shared batch driver as [`LeftRightGate`] (`TODO.md`,
+    /// container stack C2.4), which is where those anchors and the deliberate
+    /// `in_macro_code` blind spot now live as policy.
     fn left_right_closes(&self, open: usize) -> bool {
-        #[derive(PartialEq)]
-        enum Ctx {
-            Brace,
-            Env,
-            Left,
-        }
-        let mut stack: Vec<Ctx> = Vec::new();
-        let mut newlines = 0;
-        // Bounded by the last `\right` in the file ([`Self::last_right`], the
-        // `last_alias_closer` treatment): every `true` is at one, so past it
-        // only refusals remain, and a file with none refuses without scanning.
-        // The recording ignores brace nesting (a `\right` inside a `{…}` group
-        // is invisible to this scan), which only ever places the bound *past*
-        // the last viable closer. Without it, a math body of `\left` openers
-        // with no `\right` kept the stack non-empty — so the blank-line anchor
-        // never fired — and scanned each opener to the math's end: quadratic.
-        let Some(last) = self.last_right else {
-            return false;
-        };
-        let end = self
-            .macrocode_end
-            .unwrap_or(self.tokens.len())
-            .min(self.tokens.len())
-            .min(last + 1);
-        let mut i = open + 1;
-        while i < end {
-            self.tick_scan();
-            let t = &self.tokens[i];
-            // A brace group parses as [`Self::math_group`]: only its own braces
-            // steer nesting; every other token inside it is ordinary content
-            // (a stray `\right`/`\end` there is not our closer).
-            if stack.last() == Some(&Ctx::Brace) {
-                match t.kind {
-                    SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => {
-                        stack.push(Ctx::Brace)
-                    }
-                    SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
-                        stack.pop();
-                    }
-                    _ => {}
-                }
-                i += 1;
-                continue;
-            }
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newlines += 1;
-                    // A paragraph break ends the body only at its own level
-                    // (mirrors [`Self::left_right`]); inside a nested env/pair it
-                    // is ordinary trivia.
-                    if newlines >= 2 && stack.is_empty() {
-                        return false;
-                    }
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => {
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => stack.push(Ctx::Brace),
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => return false,
-                SyntaxKind::DOLLAR => return false,
-                SyntaxKind::CONTROL_SYMBOL if matches!(t.text.as_str(), "\\]" | "\\)") => {
-                    return false;
-                }
-                // `\left`/`\right` are catcode-neutral math structure that pair by
-                // *count* no matter what — [`Self::left_right`] consumes them
-                // unconditionally — so they must be counted even inside macro code.
-                // A `.dtx` `macrocode` chunk (which sets `in_def_body`) or a `\def`
-                // body is exactly where package math like `$\left#2\right#4$`
-                // (delarray.dtx) or `$\left(…\right)$` (ltmath.dtx's `\bordermatrix`)
-                // lives; gating these on `!in_macro_code` left the `\right`
-                // invisible to the scan, so the pair never opened and the closer
-                // reported a spurious "`\right` without matching `\left`" that
-                // blocked the whole file for the formatter (issue #95).
-                SyntaxKind::CONTROL_WORD if t.text.as_str() == LEFT_CMD => stack.push(Ctx::Left),
-                SyntaxKind::CONTROL_WORD if t.text.as_str() == RIGHT_CMD => match stack.last() {
-                    None => return true,
-                    Some(Ctx::Left) => {
-                        stack.pop();
-                    }
-                    _ => return false,
-                },
-                // `\begin`/`\end` are plain, non-pairing commands in macro code, so
-                // they stay gated (`AGENTS.md` decision #1).
-                SyntaxKind::CONTROL_WORD if !self.in_macro_code(i) => match t.text.as_str() {
-                    BEGIN_CMD if self.env_name_follows(i) => stack.push(Ctx::Env),
-                    END_CMD if self.env_name_follows(i) => match stack.last() {
-                        Some(Ctx::Env) => {
-                            stack.pop();
-                        }
-                        _ => return false,
-                    },
-                    _ => {}
-                },
-                _ => {}
-            }
-            newlines = 0;
-            i += 1;
-        }
-        false
+        self.gated_closer(open, &LeftRightGate, &self.left_right_batch)
+            .is_some()
     }
 
     /// Inline `$ … $` or display `$$ … $$` math. The body's atoms are wrapped in
@@ -3026,6 +3064,31 @@ impl<'t> Parser<'t> {
                 live.pop();
             }
         }
+        /// The [`Nesting::Interleaved`] twin of [`settle_level`]: settle the one
+        /// entry that owns the innermost frame, and only when no environment
+        /// stands inside it. The entries below are shielded by that frame and
+        /// keep scanning — a settled entry keeps its frame, so a later closer
+        /// still consumes it.
+        fn settle_innermost(
+            pending: &mut [Entry],
+            live: &mut Vec<usize>,
+            verdicts: &mut std::collections::HashMap<usize, Option<usize>>,
+            envs: usize,
+        ) {
+            let Some(entry) = pending.last_mut() else {
+                return;
+            };
+            if entry.settled || entry.envs_at_push != envs {
+                return;
+            }
+            entry.settled = true;
+            verdicts.insert(entry.opener, None);
+            // An unsettled top of `pending` is the topmost live entry: an entry
+            // leaves `live` only by being settled or by being popped from
+            // `pending` outright.
+            debug_assert_eq!(live.last().copied(), Some(pending.len() - 1));
+            live.pop();
+        }
         let mut verdicts = std::collections::HashMap::new();
         let mut pending = vec![Entry {
             opener: open,
@@ -3058,7 +3121,18 @@ impl<'t> Parser<'t> {
                     // \begin{tikzpicture}<blank line>… \]`, issue #70) lost its
                     // math node and reported its own `\]` as unmatched.
                     if P::PARAGRAPH_ANCHOR && newlines >= 2 && depth == 0 {
-                        settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                        // Under interleaved nesting the break is seen only by
+                        // the entry owning the innermost frame: every entry
+                        // below has that frame on its own stack, so its
+                        // `stack.is_empty()` test cannot fire ([`Nesting`]).
+                        match P::NESTING {
+                            Nesting::Counted => {
+                                settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                            }
+                            Nesting::Interleaved => {
+                                settle_innermost(&mut pending, &mut live, &mut verdicts, envs);
+                            }
+                        }
                         if live.is_empty() {
                             return verdicts;
                         }
@@ -3072,16 +3146,16 @@ impl<'t> Parser<'t> {
                 }
                 // Math swallows whatever it spans, and this scan does not model
                 // the `$`/`\[`/`\(` shape gates that decide whether a delimiter
-                // opens any. Rather than re-derive them, the positive gates
-                // refuse: a construct whose closer sits behind a math delimiter
-                // stays a plain command. A conservative false negative, per the
-                // parser's standing preference for them — and the direction a
-                // demotion gate reverses ([`GatePolicy::MATH_REFUTES`]).
-                SyntaxKind::DOLLAR if depth == 0 && P::MATH_REFUTES => break,
+                // opens any. Rather than re-derive them, a gate that lives in
+                // text refuses at math *starting*: a construct whose closer sits
+                // behind such a delimiter stays a plain command. A conservative
+                // false negative, per the parser's standing preference for them.
+                // The demotion gate reverses the direction and a gate that lives
+                // *inside* math reverses the side ([`MathAnchor`]). A `$` is both
+                // sides at once, so it anchors for either.
+                SyntaxKind::DOLLAR if depth == 0 && P::MATH_ANCHOR != MathAnchor::None => break,
                 SyntaxKind::CONTROL_SYMBOL
-                    if depth == 0
-                        && P::MATH_REFUTES
-                        && matches!(t.text.as_str(), "\\[" | "\\(") =>
+                    if depth == 0 && P::MATH_ANCHOR.anchors(t.text.as_str()) =>
                 {
                     break;
                 }
@@ -3137,6 +3211,21 @@ impl<'t> Parser<'t> {
                         let entry = pending
                             .pop()
                             .expect("a live entry remains, so pending is non-empty");
+                        // Under interleaved nesting the closer pops the
+                        // *innermost frame*, so an environment opened since this
+                        // entry is a frame mismatch — and one every outer entry
+                        // sees too, since this entry's frame is their innermost
+                        // one. It refuses the whole scan rather than one entry
+                        // ([`Nesting`]). This entry is out of `pending` already,
+                        // so it settles itself here and the trailing refusal
+                        // covers the rest.
+                        if P::NESTING == Nesting::Interleaved && envs != entry.envs_at_push {
+                            if !entry.settled {
+                                live.pop();
+                                verdicts.insert(entry.opener, None);
+                            }
+                            break;
+                        }
                         if !entry.settled {
                             live.pop();
                             // `envs == envs_at_push` for the same reason as
@@ -3184,9 +3273,25 @@ impl<'t> Parser<'t> {
                             }
                             envs += 1;
                         } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                            settle_level(&mut pending, &mut live, &mut verdicts, envs);
-                            if live.is_empty() {
-                                return verdicts;
+                            match P::NESTING {
+                                // The `\end` must find an environment innermost.
+                                // It does not when the entry on top of `pending`
+                                // was pushed at the current `envs`: that entry's
+                                // frame is in the way, for it and for every entry
+                                // below it alike, so the mismatch refuses the
+                                // whole scan. A settled entry still holds its
+                                // frame ([`Nesting`]).
+                                Nesting::Interleaved => {
+                                    if pending.last().is_some_and(|e| e.envs_at_push == envs) {
+                                        break;
+                                    }
+                                }
+                                Nesting::Counted => {
+                                    settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                                    if live.is_empty() {
+                                        return verdicts;
+                                    }
+                                }
                             }
                             // A survivor has `envs_at_push < envs`, so the
                             // decrement cannot underflow.
@@ -3823,6 +3928,17 @@ mod tests {
     #[test]
     fn env_batch_keeps_shared_frame_openers_linear() {
         let body = |n: usize| format!("{{\n{}", "\\begin{itemize}\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+    }
+
+    /// The `\left` gate's own one-closer-at-EOF shape (`TODO.md`, container
+    /// stack C2.4): a run of same-frame openers inside one math body, closed by
+    /// a single `\right` at the end. The C0 bound spans the whole run, and every
+    /// opener but the last is demoted and re-queried as the walk passes it, so
+    /// only the batch — one scan settling all of them — keeps it linear.
+    #[test]
+    fn left_right_batch_keeps_shared_frame_openers_linear() {
+        let body = |n: usize| format!("$ {}\\right)$\n", "\\left( x ".repeat(n));
         assert_scan_work_linear(&body(200), &body(400));
     }
 

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -225,6 +225,23 @@ fn debug_assert_balanced(events: &[Event]) {
     );
 }
 
+/// One batched run of the conditional gate's scan
+/// ([`Parser::conditional_closers_from`]): the per-opener verdicts it
+/// harvested, valid under the walk state in `key`.
+struct ConditionalBatch {
+    /// The walk state the scan read: `(macrocode_end, in_def_body,
+    /// group_depth > 0)`. `plain_braces` needs no slot of its own — it is
+    /// saved and restored in lockstep with `macrocode_end` per chunk
+    /// ([`Parser::macrocode_body`]), so pinning the frame pins it; everything
+    /// else the scan reads is pre-scanned token state.
+    key: (Option<usize>, bool, bool),
+    /// Opener index → the verdict [`Parser::conditional_closer`] would have
+    /// computed for it under `key`, for every same-frame opener the scan
+    /// passed. Openers absent from the map sat behind a brace during the
+    /// batch and re-batch when queried.
+    verdicts: std::collections::HashMap<usize, Option<usize>>,
+}
+
 struct Parser<'t> {
     tokens: &'t [Token],
     /// User-defined verbatim constructs, consulted to route a verbatim environment to
@@ -383,6 +400,15 @@ struct Parser<'t> {
     last_r_brace: Option<usize>,
     /// Last `\fi`-flavored flow word — bounds [`Self::conditional_closer`].
     last_fi: Option<usize>,
+    /// The most recent [`Self::conditional_closers_from`] batch, memoized with
+    /// the walk state its scan read. A lookup hits only when that key matches
+    /// the walk's current state *and* the queried opener was settled by the
+    /// batch; anything else re-batches from the queried opener. One slot is
+    /// all the reuse there is: [`Self::element`] queries each opener once, in
+    /// ascending order, under a stable state between re-batches. `RefCell`
+    /// because the gate is `&self` (the [`Self::alias_closer_memo`] pattern,
+    /// with a map where that memo keeps one verdict).
+    conditional_batch: std::cell::RefCell<Option<ConditionalBatch>>,
     /// Tokens visited by the shape-gate scans, summed over the whole parse. A
     /// measurement hook for the linearity regression tests in this file's
     /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
@@ -537,6 +563,7 @@ impl<'t> Parser<'t> {
             last_right,
             last_r_brace,
             last_fi,
+            conditional_batch: std::cell::RefCell::new(None),
             scan_work: std::cell::Cell::new(0),
             alias_openers,
             alias_closers,
@@ -2641,30 +2668,114 @@ impl<'t> Parser<'t> {
     /// and why nothing downstream may assume the two indices agree
     /// (`conditional_walk_may_close_before_the_located_fi`, `tests/parser.rs`).
     ///
-    /// **Cost.** One forward scan per live opener, bounded by the last
-    /// `\fi`-flavored flow word in the file ([`Self::last_fi`], the
-    /// `last_alias_closer` treatment): every `Some` is at one, so past it only
-    /// refusals remain, and a file with none refuses without scanning — which
-    /// is what keeps the measured pathological shape (thousands of *top-level*
-    /// openers with no blank line, no unbalanced brace, and no `\fi` at all;
-    /// 8000 such lines cost ~2s against ~0.07s unbounded) linear. Every
-    /// ordinary anchor still cuts a scan short, which is why real
-    /// conditional-heavy packages show no measurable change (`biblatex.sty`,
-    /// `latexrelease.sty`, `memoir.cls` all within noise of the pre-node
-    /// parser). The residual shape — those same openers with one `\fi` at EOF —
-    /// stays O(n·openers); see `TODO.md` (container stack, C1) for the batched
-    /// rewrite.
+    /// **Cost.** Verdicts are computed in *batches* (`TODO.md`, container-stack
+    /// C1): one forward scan seeded at the queried opener settles every
+    /// same-frame opener it passes ([`Self::conditional_closers_from`]), and
+    /// the batch is memoized against the walk state it read
+    /// ([`Self::conditional_batch`]) — so a run of top-level openers costs one
+    /// O(n) pass where it used to cost one scan each. The scan stays bounded
+    /// by the last `\fi`-flavored word in the file ([`Self::last_fi`], C0), so
+    /// a file with none refuses without scanning at all. Openers the batch did
+    /// not settle (they sat behind a brace at batch time) and queries under a
+    /// changed walk state re-batch; every ordinary anchor still cuts a scan
+    /// short, which is why real conditional-heavy packages (`biblatex.sty`,
+    /// `latexrelease.sty`, `memoir.cls`) were within noise of the pre-node
+    /// parser even before the batch.
     fn conditional_closer(&self, open: usize) -> Option<usize> {
-        let last_fi = self.last_fi?;
+        self.last_fi?;
+        let key = (self.macrocode_end, self.in_def_body, self.group_depth > 0);
+        if let Some(batch) = self.conditional_batch.borrow().as_ref()
+            && batch.key == key
+            && let Some(&verdict) = batch.verdicts.get(&open)
+        {
+            return verdict;
+        }
+        let verdicts = self.conditional_closers_from(open);
+        let verdict = verdicts.get(&open).copied();
+        debug_assert!(verdict.is_some(), "the batch must settle its own seed");
+        *self.conditional_batch.borrow_mut() = Some(ConditionalBatch { key, verdicts });
+        verdict.flatten()
+    }
+
+    /// The batched walk behind [`Self::conditional_closer`]: one forward scan
+    /// seeded at `open` that also settles, as a by-product, every opener it
+    /// passes in the seed's own brace frame — the exact verdict each one's own
+    /// scan would have computed under the current walk state.
+    ///
+    /// The transform from the per-opener scan is possible because that scan
+    /// counts nested openers only at `depth == 0`: every opener this scan
+    /// passes shares the seed's brace frame exactly, so `depth` is common to
+    /// all of them, an entry's environment count relative to itself is
+    /// `envs - envs_at_push`, and its nested-opener count is the number of
+    /// stack entries above it — `\fi` matching is pure LIFO.
+    ///
+    /// The one non-obvious rule: a refuted entry is **settled, never
+    /// removed**. The per-opener scan counts nested openers *by name*
+    /// (`conditional_openers` membership) and never un-counts one, so a later
+    /// `\fi` must still be consumed by the refuted entry's slot. In
+    /// `\ifA \begin{center} \ifB \end{center} \fi \fi`, the unowed `\end`
+    /// refutes `\ifB` — but `\ifA`'s own scan still counts `\ifB` as nested
+    /// and pairs with the *second* `\fi`. Popping `\ifB` at the `\end` would
+    /// hand the first `\fi` to `\ifA`: a different verdict, a different tree.
+    /// A `\fi` that pops an already-settled entry records nothing.
+    ///
+    /// Per anchor, mirroring the pre-batch scan token for token:
+    /// - a `\fi` at depth 0 pops the top entry; if it was still live, its
+    ///   verdict is `Some` iff no `\begin`-opened environment stands in the
+    ///   way (`envs == envs_at_push`, the old `envs == 0` restated);
+    /// - a paragraph break or an unowed `\end` refutes exactly the live
+    ///   entries at their own level (`envs_at_push == envs`) — a contiguous
+    ///   top suffix of the live stack, whose `envs_at_push` values are
+    ///   non-decreasing and capped at `envs` by construction — and the `\end`
+    ///   then decrements `envs` for the survivors;
+    /// - math, an unbalanced `}` under an enclosing group, a `macrocode`
+    ///   frame, and the end bound refute everything still live.
+    ///
+    /// The scan ends as soon as no live entry remains.
+    fn conditional_closers_from(
+        &self,
+        open: usize,
+    ) -> std::collections::HashMap<usize, Option<usize>> {
+        struct Entry {
+            opener: usize,
+            envs_at_push: usize,
+            settled: bool,
+        }
+        /// Settle every live entry sitting at its own environment level: the
+        /// level anchor at hand refutes exactly those.
+        fn settle_level(
+            pending: &mut [Entry],
+            live: &mut Vec<usize>,
+            verdicts: &mut std::collections::HashMap<usize, Option<usize>>,
+            envs: usize,
+        ) {
+            while let Some(&idx) = live.last() {
+                let entry = &mut pending[idx];
+                if entry.envs_at_push != envs {
+                    break;
+                }
+                entry.settled = true;
+                verdicts.insert(entry.opener, None);
+                live.pop();
+            }
+        }
+        let mut verdicts = std::collections::HashMap::new();
+        let mut pending = vec![Entry {
+            opener: open,
+            envs_at_push: 0,
+            settled: false,
+        }];
+        // Indices into `pending` of the entries still awaiting a verdict,
+        // ascending.
+        let mut live = vec![0usize];
         let mut depth = 0usize;
         let mut envs = 0usize;
-        let mut nested = 0usize;
         let mut newlines = 0;
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
             .min(self.tokens.len())
-            .min(last_fi + 1);
+            .min(self.last_fi.map_or(0, |last| last + 1));
         let mut i = open + 1;
         while i < end {
             self.tick_scan();
@@ -2672,8 +2783,14 @@ impl<'t> Parser<'t> {
             match t.kind {
                 SyntaxKind::NEWLINE => {
                     newlines += 1;
-                    if newlines >= 2 && Self::paragraph_break_blocks(depth, envs) {
-                        return None;
+                    // The old `paragraph_break_blocks(depth, envs)`, restated
+                    // per entry: the break blocks at an entry's own level,
+                    // `depth == 0 && envs == envs_at_push`.
+                    if newlines >= 2 && depth == 0 {
+                        settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                        if live.is_empty() {
+                            return verdicts;
+                        }
                     }
                     i += 1;
                     continue;
@@ -2688,11 +2805,11 @@ impl<'t> Parser<'t> {
                 // whose closer sits behind a math delimiter stays a plain command.
                 // A conservative false negative, per the parser's standing
                 // preference for them.
-                SyntaxKind::DOLLAR if depth == 0 => return None,
+                SyntaxKind::DOLLAR if depth == 0 => break,
                 SyntaxKind::CONTROL_SYMBOL
                     if depth == 0 && matches!(t.text.as_str(), "\\[" | "\\(") =>
                 {
-                    return None;
+                    break;
                 }
                 SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
                 SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
@@ -2704,7 +2821,7 @@ impl<'t> Parser<'t> {
                         // the scan carries on (the `\begin` gate's `group_depth`
                         // guard, transcribed).
                         if self.group_depth > 0 {
-                            return None;
+                            break;
                         }
                     } else {
                         depth -= 1;
@@ -2712,16 +2829,29 @@ impl<'t> Parser<'t> {
                 }
                 SyntaxKind::CONTROL_WORD if depth == 0 => {
                     if self.conditional_openers.contains(&i) {
-                        nested += 1;
+                        live.push(pending.len());
+                        pending.push(Entry {
+                            opener: i,
+                            envs_at_push: envs,
+                            settled: false,
+                        });
                     } else if self.conditional_flow_at(i) == Some(conditional::FlowWord::Fi) {
-                        // `envs == 0` for the same reason as `depth == 0`: a `\fi`
-                        // inside an environment the conditional opened is consumed
-                        // by that environment's body, so it is not a closer the
-                        // walk can reach.
-                        if nested == 0 {
-                            return (envs == 0).then_some(i);
+                        let entry = pending
+                            .pop()
+                            .expect("a live entry remains, so pending is non-empty");
+                        if !entry.settled {
+                            live.pop();
+                            // `envs == envs_at_push` for the same reason as
+                            // `depth == 0`: a `\fi` inside an environment the
+                            // conditional opened is consumed by that
+                            // environment's body, so it is not a closer the
+                            // walk can reach.
+                            verdicts
+                                .insert(entry.opener, (envs == entry.envs_at_push).then_some(i));
+                            if live.is_empty() {
+                                return verdicts;
+                            }
                         }
-                        nested -= 1;
                     } else if !self.in_macro_code(i) {
                         // In a definition body or an expl3 region `\begin`/`\end`
                         // are plain commands that need not pair, so neither
@@ -2742,13 +2872,16 @@ impl<'t> Parser<'t> {
                             if peek_begin_name(self.tokens, i)
                                 .is_some_and(|n| matches!(n.as_str(), "macrocode" | "macrocode*"))
                             {
-                                return None;
+                                break;
                             }
                             envs += 1;
                         } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                            if envs == 0 {
-                                return None;
+                            settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                            if live.is_empty() {
+                                return verdicts;
                             }
+                            // A survivor has `envs_at_push < envs`, so the
+                            // decrement cannot underflow.
                             envs -= 1;
                         }
                     }
@@ -2758,7 +2891,12 @@ impl<'t> Parser<'t> {
             newlines = 0;
             i += 1;
         }
-        None
+        // Global refusals — math, an unbalanced `}` under an enclosing group,
+        // a `macrocode` frame, the end bound: everything still live demotes.
+        for &idx in &live {
+            verdicts.insert(pending[idx].opener, None);
+        }
+        verdicts
     }
 
     /// The token index closing the environment-alias opener at `open`, or `None`
@@ -3417,6 +3555,16 @@ mod tests {
         // `delim_math_closes`: display-math openers, no `\]` anywhere.
         let shape = "\\[ x\n";
         assert_scan_work_linear(&shape.repeat(200), &shape.repeat(400));
+    }
+
+    /// The batched conditional gate (`TODO.md`, container stack C1): a run of
+    /// same-frame openers whose lone `\fi` sits at EOF defeats the C0
+    /// last-closer bound (the bound spans the whole file), so only the batch —
+    /// one shared scan settling every opener it passes — keeps it linear.
+    #[test]
+    fn conditional_batch_keeps_shared_frame_openers_linear() {
+        let body = |n: usize| format!("{}\\fi\n", "\\ifabc x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
     }
 
     /// The in-math no-closer shapes: the enclosing math's own gate passes (its

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -240,6 +240,14 @@ struct WalkKey {
     in_def_body: bool,
     in_group: bool,
     plain_braces: u32,
+    /// The innermost enclosing math's flavor ([`Parser::math_dollar`]), read by
+    /// [`MathBracketGate`] alone: inside `$…$` a `$` is that math's own closer
+    /// and refutes, while inside `\[…\]` it opens a *transparent* nested inline
+    /// region ([`DollarAnchor`]). Nothing else in this key moves when the flavor
+    /// does — entering a `$` inside `\[…\]` changes no brace, group, or frame
+    /// state — so without it a batch harvested under one flavor would answer for
+    /// the other.
+    enclosing_math_is_dollar: bool,
 }
 
 /// One batched run of a shape gate's scan ([`Parser::gate_batch`]): the
@@ -308,7 +316,7 @@ enum MathAnchor {
 impl MathAnchor {
     /// Whether the control symbol `text` anchors under this policy. `$` is
     /// handled by the driver's own [`SyntaxKind::DOLLAR`] arm, since it is both
-    /// an opener and a closer.
+    /// an opener and a closer ([`DollarAnchor`]).
     fn anchors(self, text: &str) -> bool {
         match self {
             MathAnchor::None => false,
@@ -316,6 +324,64 @@ impl MathAnchor {
             MathAnchor::Closing => matches!(text, "\\]" | "\\)"),
         }
     }
+}
+
+/// What a `$` at the entries' own brace level means — the one axis a gate reads
+/// at *runtime* rather than from a const, because [`MathBracketGate`] decides it
+/// from the enclosing math's flavor.
+///
+/// It is separate from [`MathAnchor`] because a `$` is both sides of the
+/// delimited pair at once, so the two-sided question that enum answers does not
+/// apply to it, and because it has a third reading no delimiter has.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DollarAnchor {
+    /// Ordinary content: the math gates, whose own closer it is.
+    Content,
+    /// Refutes every live entry, the reading of every gate that anchors on math
+    /// at all — a `$` opens math for a text-dwelling gate and ends it for a
+    /// math-dwelling one.
+    Refutes,
+    /// Toggles a **transparent** nested inline region: the entries' own openers
+    /// and closers stop counting until the matching `$`, and everything else
+    /// (braces, the paragraph run, the delimiter and environment anchors) reads
+    /// on unchanged. [`MathBracketGate`] inside `\[…\]`/`\(…\)` or a math
+    /// environment, where a `$` really does open a nested inline region, so a
+    /// balanced `$…$` inside the bracket is content rather than a boundary
+    /// (`\[ \inferrule*[right=$\Pi$-eq]{A}{B} \]`). An unbalanced `$` leaves the
+    /// region open, so no `]` is ever accepted and the scan runs to its bound.
+    Transparent,
+}
+
+/// Whether a blank line refutes an entry, and at what brace level.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ParagraphAnchor {
+    /// Never. An alias body legitimately spans blank lines, and an environment's
+    /// escaping `}` may sit paragraphs away.
+    None,
+    /// At an entry's *own* level (`depth == 0 && envs == envs_at_push`) only.
+    /// Deeper than that a break is ordinary body trivia, and a gate stricter
+    /// than the parse it guards drops the node: a display equation built out of
+    /// `tikzpicture` cells (issue #70) lost its math node this way.
+    OwnLevel,
+    /// At any depth, refuting every live entry outright. The bracket family:
+    /// [`Parser::optional`] bails at a paragraph break wherever the cursor
+    /// stands, since an unclosed `[` must never swallow the document, so its
+    /// gates mirror that.
+    AnyDepth,
+}
+
+/// What a `\begin`/`\end` pair between an entry and the token at hand means.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EnvAnchor {
+    /// Counted, so a closer inside an environment the construct opened is known
+    /// to be out of the walk's reach (`envs`/`envs_at_push`). Every gate whose
+    /// construct may legitimately span one.
+    Counts,
+    /// Refutes every live entry outright, in *both* halves. The bracket family:
+    /// [`Parser::optional`] bails at a `\begin` as readily as at an `\end`
+    /// (either means a runaway `[`), so there is no shape in which an optional
+    /// spans an environment and nothing to count.
+    Refutes,
 }
 
 /// How a gate's nested entries relate to the `\begin`-opened environments
@@ -364,14 +430,26 @@ enum Nesting {
 /// brace level, since the math gates close on a `DOLLAR` and a `CONTROL_SYMBOL`
 /// — every policy tests the kind inside its own predicate anyway.
 trait GatePolicy {
-    /// Whether a blank line at an entry's own level refutes it. True for
-    /// conditionals, which mirror a parse that stops at a `\par`; false for
-    /// aliases, whose body legitimately spans blank lines.
-    const PARAGRAPH_ANCHOR: bool;
+    /// Whether a blank line refutes an entry, and at what level. `OwnLevel` for
+    /// conditionals, which mirror a parse that stops at a `\par`; `None` for
+    /// aliases, whose body legitimately spans blank lines. See
+    /// [`ParagraphAnchor`].
+    const PARAGRAPH_ANCHOR: ParagraphAnchor;
 
     /// What a `}` at the entries' own brace level means. Defaults to the
     /// *positive* gates' reading; see [`StrayBrace`].
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesInGroup;
+
+    /// Whether a brace with no match inside the current `macrocode` chunk
+    /// ([`Parser::plain_braces`]) is an ordinary token rather than group
+    /// structure. True everywhere but [`MathBracketGate`], whose pre-batch scan
+    /// tracked every brace alike — preserved, not chosen, and one-directional:
+    /// a chunk-unmatched `}` can only occur at chunk brace depth 0, so the scan
+    /// meets it at its own depth 0 and refuses, while a chunk-unmatched `{` only
+    /// adds depth. The unfiltered reading therefore refuses a bracket the
+    /// filtered one would attach and never the reverse (`TODO.md`, container
+    /// stack C2.5).
+    const PLAIN_BRACES_ARE_TOKENS: bool = true;
 
     /// Which math delimiters at the entries' own level refute them, if any.
     ///
@@ -391,8 +469,12 @@ trait GatePolicy {
     /// one token past the `\begin`, never saw either.
     const OPENER_IS_ENV_BEGIN: bool = false;
 
-    /// Whether `\begin`/`\end` count toward `envs` at *any* brace depth, rather
-    /// than only at the entries' own.
+    /// Whether the `\begin`/`\end` and math-*delimiter* anchors apply at any
+    /// brace depth, rather than only at the entries' own. (A `$` is read at the
+    /// entries' own level whatever this says — every gate's pre-batch scan did,
+    /// and for [`MathBracketGate`] a `$` inside a group is not the boundary its
+    /// depth-0 twin is. The paragraph anchor has its own knob for the same
+    /// reason, [`ParagraphAnchor`].)
     ///
     /// False for the gates whose entries pair at their own brace level: an
     /// environment opened inside a `{…}` group is closed inside it too, so
@@ -400,8 +482,37 @@ trait GatePolicy {
     /// closer. The math gates set it true, as their pre-batch scans did: a math
     /// body descends into a group ([`Parser::math_group`]) and keeps parsing
     /// environments there, so `envs` tracks the whole body rather than one
-    /// brace level of it.
-    const ENVS_AT_ANY_DEPTH: bool = false;
+    /// brace level of it. The bracket gates set it true because
+    /// [`Parser::optional`]'s bail is depth-blind: a `\begin` inside a group is
+    /// still a runaway `[`.
+    const ANCHORS_AT_ANY_DEPTH: bool = false;
+
+    /// What a `\begin`/`\end` between an entry and the token at hand means. See
+    /// [`EnvAnchor`]; only the bracket family refuses rather than counts.
+    const ENV_ANCHOR: EnvAnchor = EnvAnchor::Counts;
+
+    /// Whether that anchor also fires *inside macro code*, where `\begin`/`\end`
+    /// are plain commands that need not pair (issues #45/#60) and every other
+    /// gate therefore ignores them.
+    ///
+    /// True for [`MathBracketGate`] alone, whose pre-batch scan carried no such
+    /// filter — so it is stricter than the [`Parser::optional`] bail it mirrors,
+    /// which does carry one. Preserved, not chosen: the divergence only ever
+    /// refuses a bracket, the conservative direction (`TODO.md`, container stack
+    /// C2.5).
+    const ENV_ANCHOR_IN_MACRO_CODE: bool = false;
+
+    /// Whether a `.dtx` doc margin or docstrip guard is transparent to the
+    /// paragraph run, as it is to [`TriviaScan::saw_blank_line`].
+    ///
+    /// False for [`MacrocodeBracketGate`], whose pre-batch scan skipped
+    /// `WHITESPACE` alone, so a guard line between two newlines breaks the run
+    /// there. That is in fact the [`TriviaScan::saw_blank_line_outside_guards`]
+    /// reading — docstrip *deletes* a guard-only line, so it does not part what
+    /// surrounds it (issue #71) — which the other gates do not take. Preserved
+    /// on both sides rather than unified, since unifying moves verdicts either
+    /// way (`TODO.md`, container stack C2.5).
+    const DOC_TRIVIA_FLOATS: bool = true;
 
     /// Whether a closer only settles an entry when no `\begin`-opened
     /// environment stands in the way (`envs == envs_at_push`).
@@ -424,6 +535,20 @@ trait GatePolicy {
     /// because C2 migrates verdicts unchanged, not because it is the better
     /// reading.
     const MACROCODE_FRAME_ANCHORS: bool = true;
+
+    /// What a `$` at the entries' own brace level means. Defaults to the
+    /// two-sided reading of [`Self::MATH_ANCHOR`]: a `$` is an opening *and* a
+    /// closing delimiter, so a gate that anchors on either side anchors on it,
+    /// and only a gate for which math delimiters are content reads it as
+    /// content too. [`MathBracketGate`] overrides it — the one gate that needs
+    /// the enclosing math's flavor, which is walk state and cannot ride a const.
+    fn dollar_anchor(&self) -> DollarAnchor {
+        if Self::MATH_ANCHOR == MathAnchor::None {
+            DollarAnchor::Content
+        } else {
+            DollarAnchor::Refutes
+        }
+    }
 
     /// The last index in the file that could ever settle an entry with a
     /// closer — the C0 bound. `None` refuses the whole gate without scanning.
@@ -450,7 +575,7 @@ trait GatePolicy {
 struct ConditionalGate;
 
 impl GatePolicy for ConditionalGate {
-    const PARAGRAPH_ANCHOR: bool = true;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::OwnLevel;
 
     fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
         p.last_fi
@@ -485,7 +610,7 @@ impl GatePolicy for ConditionalGate {
 struct AliasGate;
 
 impl GatePolicy for AliasGate {
-    const PARAGRAPH_ANCHOR: bool = false;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::None;
 
     fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
         p.last_alias_closer
@@ -530,7 +655,7 @@ impl GatePolicy for AliasGate {
 struct EnvGate;
 
 impl GatePolicy for EnvGate {
-    const PARAGRAPH_ANCHOR: bool = false;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::None;
     const STRAY_BRACE: StrayBrace = StrayBrace::ClosesInGroup;
     const MATH_ANCHOR: MathAnchor = MathAnchor::None;
     const OPENER_IS_ENV_BEGIN: bool = true;
@@ -569,7 +694,7 @@ impl GatePolicy for EnvGate {
 /// - **Math is not an anchor** ([`MathAnchor::None`]) — a foreign
 ///   delimiter is ordinary content here, and for [`DollarGate`] the delimiter
 ///   *is* the closer.
-/// - **Environments count at any depth** ([`GatePolicy::ENVS_AT_ANY_DEPTH`]).
+/// - **Environments count at any depth** ([`GatePolicy::ANCHORS_AT_ANY_DEPTH`]).
 /// - **The closer needs no environment balance**
 ///   ([`GatePolicy::CLOSER_NEEDS_ENV_BALANCE`]).
 ///
@@ -586,10 +711,10 @@ struct DelimMathGate {
 }
 
 impl GatePolicy for DelimMathGate {
-    const PARAGRAPH_ANCHOR: bool = true;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::OwnLevel;
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
     const MATH_ANCHOR: MathAnchor = MathAnchor::None;
-    const ENVS_AT_ANY_DEPTH: bool = true;
+    const ANCHORS_AT_ANY_DEPTH: bool = true;
     const CLOSER_NEEDS_ENV_BALANCE: bool = false;
     const MACROCODE_FRAME_ANCHORS: bool = false;
 
@@ -629,10 +754,10 @@ struct DollarGate {
 }
 
 impl GatePolicy for DollarGate {
-    const PARAGRAPH_ANCHOR: bool = true;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::OwnLevel;
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
     const MATH_ANCHOR: MathAnchor = MathAnchor::None;
-    const ENVS_AT_ANY_DEPTH: bool = true;
+    const ANCHORS_AT_ANY_DEPTH: bool = true;
     const CLOSER_NEEDS_ENV_BALANCE: bool = false;
     const MACROCODE_FRAME_ANCHORS: bool = false;
 
@@ -689,7 +814,7 @@ impl GatePolicy for DollarGate {
 struct LeftRightGate;
 
 impl GatePolicy for LeftRightGate {
-    const PARAGRAPH_ANCHOR: bool = true;
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::OwnLevel;
     const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
     const MATH_ANCHOR: MathAnchor = MathAnchor::Closing;
     const NESTING: Nesting = Nesting::Interleaved;
@@ -712,6 +837,157 @@ impl GatePolicy for LeftRightGate {
     fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
         let t = &p.tokens[i];
         t.kind == SyntaxKind::CONTROL_WORD && t.text.as_str() == RIGHT_CMD
+    }
+}
+
+/// What the three **bracket** gates share (`TODO.md`, container stack C2.5).
+/// Each asks whether the `]` closing a `[` is reachable before the token that
+/// would make [`Parser::optional`] bail, in the mode the bracket sits in — text,
+/// math, or a `macrocode` chunk.
+///
+/// Their nesting is what the migration turned out to be about. A per-opener
+/// bracket scan counts the `]`s *owed* to the command-abutting `[`s it passes:
+/// such a `[` is itself argument-shaped (or a `\left`/`\Big` delimiter) and will
+/// claim the next `]` when parsed, so that `]` cannot also satisfy the outer one
+/// (`\P[\gamma[0, \infty) \cap A = \emptyset]`, issue #55). That claim countdown
+/// **is** the driver's nested-opener stack once an opener is defined as a
+/// command-abutting `[` — closer matching is pure LIFO either way — so the
+/// family needed no new nesting model, only the two anchors it reads
+/// differently:
+///
+/// - **A `\begin`/`\end` refutes rather than counts** ([`EnvAnchor::Refutes`]),
+///   in both halves: an optional never legitimately spans an environment, so
+///   either half means a runaway `[`.
+/// - **Both that anchor and the paragraph break are depth-blind**
+///   ([`GatePolicy::ANCHORS_AT_ANY_DEPTH`], [`ParagraphAnchor::AnyDepth`]),
+///   because `optional`'s own bail is: it bails wherever the cursor stands, and
+///   a gate stricter *or* looser than the parse it guards is a bug.
+///
+/// A `}` refutes unconditionally ([`StrayBrace::RefutesAlways`]) for the reason
+/// the math gates give: `optional` bails at any unbalanced `}`, group behind it
+/// or not.
+///
+/// [`Parser::bracket_closes_in_text`]'s own policy is this and nothing else — it
+/// is the text-mode gate, and macro code's freely-passed lone brackets
+/// (`\@ifnextchar [\@xmpar\@ympar`, issue #60) are exactly what it exists to
+/// leave alone.
+struct TextBracketGate;
+
+impl GatePolicy for TextBracketGate {
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::AnyDepth;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::None;
+    const ANCHORS_AT_ANY_DEPTH: bool = true;
+    const ENV_ANCHOR: EnvAnchor = EnvAnchor::Refutes;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_r_bracket
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.bracket_abuts_command(i)
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.tokens[i].kind == SyntaxKind::R_BRACKET
+    }
+}
+
+/// [`Parser::bracket_closes_before_math_end`]'s policy: the bracket gate that
+/// runs lexically inside math. The family's policy is documented on
+/// [`TextBracketGate`]; three things are this gate's own, and all three are
+/// **preserved** from its pre-batch scan rather than chosen (`TODO.md`,
+/// container stack C2.5).
+///
+/// - **A `$` depends on the enclosing math's flavor**
+///   ([`GatePolicy::dollar_anchor`]). Inside `\[…\]` it opens a genuine nested
+///   inline region, so a balanced `$…$` in the bracket is
+///   [`DollarAnchor::Transparent`]; inside `$…$` TeX cannot nest one, so the
+///   first depth-0 `$` is *this* math's closer and refutes — without which a
+///   missing `]` in dollar math (`$\mathcal{N}[\mathcal{S}$`, issue #99) scanned
+///   into the following math and attached an optional that swallowed the closing
+///   `$`. That flavor is walk state, so it rides [`WalkKey`].
+/// - **`\]`/`\)` refute** ([`MathAnchor::Closing`]): inside math they mean the
+///   bracket is not an argument at all, e.g. the open-interval `$]0;\num{0.5}[$`.
+/// - **The `\begin`/`\end` anchor fires inside macro code too**
+///   ([`GatePolicy::ENV_ANCHOR_IN_MACRO_CODE`]), and chunk-unmatched braces are
+///   not plain tokens ([`GatePolicy::PLAIN_BRACES_ARE_TOKENS`]). Both make it
+///   stricter than the [`Parser::optional`] bail it mirrors, in the direction
+///   that only ever declines to attach.
+struct MathBracketGate {
+    /// Whether the innermost enclosing math is `$…$`/`$$…$$`
+    /// ([`Parser::math_dollar`]).
+    enclosing_is_dollar: bool,
+}
+
+impl GatePolicy for MathBracketGate {
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::AnyDepth;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::Closing;
+    const ANCHORS_AT_ANY_DEPTH: bool = true;
+    const ENV_ANCHOR: EnvAnchor = EnvAnchor::Refutes;
+    const ENV_ANCHOR_IN_MACRO_CODE: bool = true;
+    const PLAIN_BRACES_ARE_TOKENS: bool = false;
+
+    fn dollar_anchor(&self) -> DollarAnchor {
+        if self.enclosing_is_dollar {
+            DollarAnchor::Refutes
+        } else {
+            DollarAnchor::Transparent
+        }
+    }
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_r_bracket
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.bracket_abuts_command(i)
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.tokens[i].kind == SyntaxKind::R_BRACKET
+    }
+}
+
+/// [`Parser::bracket_closes_before_macrocode_end`]'s policy: inside a `macrocode`
+/// chunk a `[` is an argument only when its `]` closes *within* the chunk, whose
+/// frame is an absolute terminator. Two divergences from its two siblings, both
+/// preserved from its pre-batch scan:
+///
+/// - **It is single-entry** ([`GatePolicy::opens_at`] always false): the scan
+///   ran no claim countdown, so the first `]` at brace level settles the seed.
+///   That is also why it is the one bracket gate the batch cannot make linear —
+///   there is no neighbor to settle — and it runs unmemoized like the math
+///   gates.
+/// - **A doc margin or guard breaks the paragraph run**
+///   ([`GatePolicy::DOC_TRIVIA_FLOATS`]), where every other gate floats it.
+///
+/// Its [`EnvAnchor`] can never fire: a chunk body sets `in_def_body`
+/// ([`Parser::macrocode_body`]), so `in_macro_code` holds at every index the
+/// scan can reach and the driver's filter takes the arm out — which is the
+/// pre-batch scan's silence about `\begin`/`\end` restated as the reason for it,
+/// rather than as an omission.
+struct MacrocodeBracketGate;
+
+impl GatePolicy for MacrocodeBracketGate {
+    const PARAGRAPH_ANCHOR: ParagraphAnchor = ParagraphAnchor::AnyDepth;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_ANCHOR: MathAnchor = MathAnchor::None;
+    const ANCHORS_AT_ANY_DEPTH: bool = true;
+    const ENV_ANCHOR: EnvAnchor = EnvAnchor::Refutes;
+    const DOC_TRIVIA_FLOATS: bool = false;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_r_bracket
+    }
+
+    fn opens_at(&self, _p: &Parser<'_>, _i: usize) -> bool {
+        false
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.tokens[i].kind == SyntaxKind::R_BRACKET
     }
 }
 
@@ -914,6 +1190,14 @@ struct Parser<'t> {
     /// as a plain command and every `\left` after it asked in turn — so the
     /// batch is what keeps a run of them from being quadratic.
     left_right_batch: std::cell::RefCell<Option<GateBatch>>,
+    /// The [`TextBracketGate`] twin of [`Self::conditional_batch`]. A `[` the
+    /// gate refuses stays an ordinary token the walk steps over, and the next
+    /// command-abutting `[` is asked in turn, so a run of them re-scanned per
+    /// opener before the batch.
+    text_bracket_batch: std::cell::RefCell<Option<GateBatch>>,
+    /// The [`MathBracketGate`] twin, keyed like the others — including on the
+    /// enclosing math's flavor, which this gate alone reads ([`WalkKey`]).
+    math_bracket_batch: std::cell::RefCell<Option<GateBatch>>,
     /// Token index of the alias closer bounding the environment body currently
     /// being parsed, if any. Saved and restored around the body in
     /// [`Self::alias_environment`]. An alias environment has no `\end{…}` to stop
@@ -1067,6 +1351,8 @@ impl<'t> Parser<'t> {
             alias_batch: std::cell::RefCell::new(None),
             env_batch: std::cell::RefCell::new(None),
             left_right_batch: std::cell::RefCell::new(None),
+            text_bracket_batch: std::cell::RefCell::new(None),
+            math_bracket_batch: std::cell::RefCell::new(None),
             alias_end: None,
         }
     }
@@ -2068,6 +2354,11 @@ impl<'t> Parser<'t> {
         self.close();
     }
 
+    /// One tick per token a shape-gate scan visits, into [`Self::scan_work`].
+    fn tick_scan(&self) {
+        self.scan_work.set(self.scan_work.get() + 1);
+    }
+
     /// True if the `[` at token index `open` is closed by a `]` before the
     /// current macrocode chunk's frame terminator. Depth-tracks only the braces
     /// that really form groups (chunk-matched ones — [`Self::plain_braces`] are
@@ -2076,45 +2367,20 @@ impl<'t> Parser<'t> {
     /// over several lines still attaches on the second pass. Keeps a code
     /// bracket (`\@tempcnta[` with no `]` in the chunk) an ordinary token
     /// instead of an optional that would swallow the frame.
-    /// One tick per token a shape-gate scan visits, into [`Self::scan_work`].
-    fn tick_scan(&self) {
-        self.scan_work.set(self.scan_work.get() + 1);
-    }
-
+    ///
+    /// Runs on the shared batch driver as [`MacrocodeBracketGate`] (`TODO.md`,
+    /// container stack C2.5), which carries the chunk frame as its bound and
+    /// adds the C0 last-`]` bound the hand-written scan never had. It is the one
+    /// bracket gate the batch cannot make linear: single-entry by policy, so a
+    /// chunk of `\cmd[` atoms whose only `]` sits outside it still scans to the
+    /// frame per opener.
     fn bracket_closes_before_macrocode_end(&self, open: usize) -> bool {
-        let Some(end) = self.macrocode_end else {
+        // Total in `open` for a caller outside a chunk, where the frame that
+        // bounds this gate does not exist and every `[` passes.
+        if self.macrocode_end.is_none() {
             return true;
-        };
-        let mut depth = 0usize;
-        let mut newline_run = 0;
-        for (off, t) in self.tokens[open + 1..end.min(self.tokens.len())]
-            .iter()
-            .enumerate()
-        {
-            self.tick_scan();
-            let idx = open + 1 + off;
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newline_run += 1;
-                    if newline_run >= 2 {
-                        return false;
-                    }
-                    continue;
-                }
-                SyntaxKind::WHITESPACE => continue,
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&idx) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&idx) => {
-                    if depth == 0 {
-                        return false;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::R_BRACKET if depth == 0 => return true,
-                _ => {}
-            }
-            newline_run = 0;
         }
-        false
+        self.gate_verdict(open, &MacrocodeBracketGate).is_some()
     }
 
     /// True if the `[` at token index `open` is closed by a `]` before a token
@@ -2149,71 +2415,19 @@ impl<'t> Parser<'t> {
     ///   a missing `]`, stacks-project issue #99) would scan past the closing
     ///   `$` into following math and wrongly attach an optional that swallows
     ///   it. Does not consume.
+    ///
+    /// Runs on the shared batch driver as [`MathBracketGate`] (`TODO.md`,
+    /// container stack C2.5), where the transparent `$…$` region, the flavor
+    /// that decides it, and the gate's two preserved strictnesses (a
+    /// `\begin`/`\end` anchors inside macro code too, and a chunk-unmatched
+    /// brace is group structure) are named policies. The enclosing flavor is
+    /// walk state, so it rides the batch's memo key ([`WalkKey`]).
     fn bracket_closes_before_math_end(&self, open: usize) -> bool {
-        let enclosing_is_dollar = self.math_dollar.last().copied().unwrap_or(false);
-        // Every `true` is at an `R_BRACKET`, so the scan is bounded by the last
-        // one in the file ([`Self::last_r_bracket`]); with none past the opener
-        // it refuses outright. Without the bound, a math body of `\cmd[` atoms
-        // with no `]` anywhere scanned each one to its math's end — quadratic.
-        let Some(last) = self.last_r_bracket.filter(|&last| last > open) else {
-            return false;
+        let gate = MathBracketGate {
+            enclosing_is_dollar: self.enclosing_math_is_dollar(),
         };
-        let mut depth = 0usize;
-        let mut brackets = 0usize;
-        let mut in_inline = false;
-        let mut newlines = 0;
-        let mut abuts_command = false;
-        for (off, t) in self.tokens[open + 1..=last].iter().enumerate() {
-            self.tick_scan();
-            let idx = open + 1 + off;
-            let prev_abuts_command = abuts_command;
-            abuts_command = false;
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newlines += 1;
-                    if newlines >= 2 {
-                        return false;
-                    }
-                    continue;
-                }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => continue,
-                SyntaxKind::L_BRACE => depth += 1,
-                SyntaxKind::R_BRACE => {
-                    if depth == 0 {
-                        return false;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::DOLLAR if depth == 0 => {
-                    if enclosing_is_dollar {
-                        return false;
-                    }
-                    in_inline = !in_inline;
-                }
-                SyntaxKind::L_BRACKET if depth == 0 && !in_inline && prev_abuts_command => {
-                    brackets += 1
-                }
-                SyntaxKind::R_BRACKET if depth == 0 && !in_inline => {
-                    if brackets == 0 {
-                        return true;
-                    }
-                    brackets -= 1;
-                }
-                SyntaxKind::CONTROL_SYMBOL if matches!(t.text.as_str(), "\\]" | "\\)") => {
-                    return false;
-                }
-                SyntaxKind::CONTROL_WORD
-                    if matches!(t.text.as_str(), BEGIN_CMD | END_CMD)
-                        && self.env_name_follows(idx) =>
-                {
-                    return false;
-                }
-                SyntaxKind::CONTROL_WORD | SyntaxKind::CONTROL_SYMBOL => abuts_command = true,
-                _ => {}
-            }
-            newlines = 0;
-        }
-        false
+        self.gated_closer(open, &gate, &self.math_bracket_batch)
+            .is_some()
     }
 
     /// True if the `[` at token index `open` is closed by a `]` before a token
@@ -2231,60 +2445,17 @@ impl<'t> Parser<'t> {
     /// [`Self::bracket_closes_before_math_end`] (issue #55). A gated bracket
     /// stays an ordinary token with **no diagnostic**: in code the shape is
     /// routine, so it is not statically an error. Does not consume.
+    ///
+    /// Runs on the shared batch driver as [`TextBracketGate`] (`TODO.md`,
+    /// container stack C2.5). The claim countdown above *is* the driver's
+    /// nested-opener stack — closer matching is LIFO either way — so one scan
+    /// now settles every command-abutting `[` in the seed's own brace frame,
+    /// where a refused bracket used to leave the walk to ask the next one from
+    /// scratch. The C0 bound (the last `]` in the file) rides
+    /// [`GatePolicy::last_closer`].
     fn bracket_closes_in_text(&self, open: usize) -> bool {
-        // Bounded by the last `]` in the file ([`Self::last_r_bracket`]), the
-        // `last_alias_closer` treatment: past it only refusals remain, and with
-        // none past the opener the gate refuses without scanning. Without the
-        // bound, a file of `\cmd[` lines with no `]` and no blank line scanned
-        // each opener to EOF — quadratic (`TODO.md`, container stack C0).
-        let Some(last) = self.last_r_bracket.filter(|&last| last > open) else {
-            return false;
-        };
-        let mut depth = 0usize;
-        let mut brackets = 0usize;
-        let mut newlines = 0;
-        let mut abuts_command = false;
-        for (off, t) in self.tokens[open + 1..=last].iter().enumerate() {
-            self.tick_scan();
-            let idx = open + 1 + off;
-            let prev_abuts_command = abuts_command;
-            abuts_command = false;
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newlines += 1;
-                    if newlines >= 2 {
-                        return false;
-                    }
-                    continue;
-                }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => continue,
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&idx) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&idx) => {
-                    if depth == 0 {
-                        return false;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::L_BRACKET if depth == 0 && prev_abuts_command => brackets += 1,
-                SyntaxKind::R_BRACKET if depth == 0 => {
-                    if brackets == 0 {
-                        return true;
-                    }
-                    brackets -= 1;
-                }
-                SyntaxKind::CONTROL_WORD
-                    if !self.in_macro_code(idx)
-                        && matches!(t.text.as_str(), BEGIN_CMD | END_CMD)
-                        && self.env_name_follows(idx) =>
-                {
-                    return false;
-                }
-                SyntaxKind::CONTROL_WORD | SyntaxKind::CONTROL_SYMBOL => abuts_command = true,
-                _ => {}
-            }
-            newlines = 0;
-        }
-        false
+        self.gated_closer(open, &TextBracketGate, &self.text_bracket_batch)
+            .is_some()
     }
 
     /// True if the `$` (or `$$`) opener at token index `open` is closed by a
@@ -2943,7 +3114,30 @@ impl<'t> Parser<'t> {
             in_def_body: self.in_def_body,
             in_group: self.group_depth > 0,
             plain_braces: self.plain_braces_version,
+            enclosing_math_is_dollar: self.enclosing_math_is_dollar(),
         }
+    }
+
+    /// Whether the innermost enclosing math body is dollar-delimited
+    /// ([`Self::math_dollar`]). Outside math the answer is unused; `false` is
+    /// the reading a bracket gate would take there anyway.
+    fn enclosing_math_is_dollar(&self) -> bool {
+        self.math_dollar.last().copied().unwrap_or(false)
+    }
+
+    /// Whether the token at `i` is a `[` that **directly abuts** a command, and
+    /// so claims the next `]` for itself when parsed — the bracket family's
+    /// nested opener ([`TextBracketGate`]). The pre-batch scans derived this
+    /// from a running `abuts_command` flag that every token kind but a control
+    /// word or symbol cleared, trivia included, which is this test one token
+    /// back.
+    fn bracket_abuts_command(&self, i: usize) -> bool {
+        self.tokens[i].kind == SyntaxKind::L_BRACKET
+            && i > 0
+            && matches!(
+                self.tokens[i - 1].kind,
+                SyntaxKind::CONTROL_WORD | SyntaxKind::CONTROL_SYMBOL
+            )
     }
 
     /// The memoized front of [`Self::gate_batch`]: answer `open` from `memo`
@@ -3101,6 +3295,10 @@ impl<'t> Parser<'t> {
         let mut depth = 0usize;
         let mut envs = 0usize;
         let mut newlines = 0;
+        // Inside a `$…$` region the entries read *through*: their openers and
+        // closers stop counting until the matching `$`. Only
+        // [`DollarAnchor::Transparent`] ever sets it.
+        let mut transparent = false;
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
@@ -3119,8 +3317,20 @@ impl<'t> Parser<'t> {
                     // parse it guards drops the node: a display equation built
                     // out of `tikzpicture` cells (`\[ \begin{array}…
                     // \begin{tikzpicture}<blank line>… \]`, issue #70) lost its
-                    // math node and reported its own `\]` as unmatched.
-                    if P::PARAGRAPH_ANCHOR && newlines >= 2 && depth == 0 {
+                    // math node and reported its own `\]` as unmatched. The
+                    // bracket family is the exception, and for the same reason:
+                    // `optional` bails at a break wherever the cursor stands
+                    // ([`ParagraphAnchor::AnyDepth`]).
+                    if newlines >= 2
+                        && match P::PARAGRAPH_ANCHOR {
+                            ParagraphAnchor::None => false,
+                            ParagraphAnchor::OwnLevel => depth == 0,
+                            ParagraphAnchor::AnyDepth => true,
+                        }
+                    {
+                        if P::PARAGRAPH_ANCHOR == ParagraphAnchor::AnyDepth {
+                            break;
+                        }
                         // Under interleaved nesting the break is seen only by
                         // the entry owning the innermost frame: every entry
                         // below has that frame on its own stack, so its
@@ -3140,7 +3350,11 @@ impl<'t> Parser<'t> {
                     i += 1;
                     continue;
                 }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => {
+                SyntaxKind::WHITESPACE => {
+                    i += 1;
+                    continue;
+                }
+                SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD if P::DOC_TRIVIA_FLOATS => {
                     i += 1;
                     continue;
                 }
@@ -3152,15 +3366,32 @@ impl<'t> Parser<'t> {
                 // false negative, per the parser's standing preference for them.
                 // The demotion gate reverses the direction and a gate that lives
                 // *inside* math reverses the side ([`MathAnchor`]). A `$` is both
-                // sides at once, so it anchors for either.
-                SyntaxKind::DOLLAR if depth == 0 && P::MATH_ANCHOR != MathAnchor::None => break,
-                SyntaxKind::CONTROL_SYMBOL
-                    if depth == 0 && P::MATH_ANCHOR.anchors(t.text.as_str()) =>
+                // sides at once, so it anchors for either — unless it opens a
+                // region the gate reads *through* ([`DollarAnchor`]).
+                SyntaxKind::DOLLAR
+                    if depth == 0 && policy.dollar_anchor() == DollarAnchor::Refutes =>
                 {
                     break;
                 }
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
+                SyntaxKind::DOLLAR
+                    if depth == 0 && policy.dollar_anchor() == DollarAnchor::Transparent =>
+                {
+                    transparent = !transparent;
+                }
+                SyntaxKind::CONTROL_SYMBOL
+                    if (depth == 0 || P::ANCHORS_AT_ANY_DEPTH)
+                        && P::MATH_ANCHOR.anchors(t.text.as_str()) =>
+                {
+                    break;
+                }
+                SyntaxKind::L_BRACE
+                    if !P::PLAIN_BRACES_ARE_TOKENS || !self.plain_braces.contains(&i) =>
+                {
+                    depth += 1
+                }
+                SyntaxKind::R_BRACE
+                    if !P::PLAIN_BRACES_ARE_TOKENS || !self.plain_braces.contains(&i) =>
+                {
                     if depth == 0 {
                         // A `}` closing a group opened before the opener always
                         // wins: braces are catcode structure while the gated
@@ -3193,7 +3424,7 @@ impl<'t> Parser<'t> {
                 // tests the kind inside its own predicate, so asking wider costs
                 // the narrow ones nothing but the call.
                 _ => {
-                    if depth == 0 && policy.opens_at(self, i) {
+                    if !transparent && depth == 0 && policy.opens_at(self, i) {
                         // A gate whose openers are `\begin`s counts this one
                         // before pushing, so the entry's own environment is not
                         // in its `envs_at_push` — its per-opener scan starts one
@@ -3207,7 +3438,7 @@ impl<'t> Parser<'t> {
                             envs_at_push: envs,
                             settled: false,
                         });
-                    } else if depth == 0 && policy.closes_at(self, i) {
+                    } else if !transparent && depth == 0 && policy.closes_at(self, i) {
                         let entry = pending
                             .pop()
                             .expect("a live entry remains, so pending is non-empty");
@@ -3244,12 +3475,14 @@ impl<'t> Parser<'t> {
                             }
                         }
                     } else if t.kind == SyntaxKind::CONTROL_WORD
-                        && (depth == 0 || P::ENVS_AT_ANY_DEPTH)
-                        && !self.in_macro_code(i)
+                        && (depth == 0 || P::ANCHORS_AT_ANY_DEPTH)
+                        && (P::ENV_ANCHOR_IN_MACRO_CODE || !self.in_macro_code(i))
                     {
                         // In a definition body or an expl3 region `\begin`/`\end`
                         // are plain commands that need not pair, so neither
-                        // anchors nor nests there (issues #45/#60).
+                        // anchors nor nests there (issues #45/#60) — bar the one
+                        // gate whose pre-batch scan never carried the filter
+                        // ([`GatePolicy::ENV_ANCHOR_IN_MACRO_CODE`]).
                         if t.text.as_str() == BEGIN_CMD && self.env_name_follows(i) {
                             // A `macrocode` chunk is a hard boundary in both
                             // directions: docstrip is line-oriented, so the code
@@ -3271,8 +3504,18 @@ impl<'t> Parser<'t> {
                             {
                                 break;
                             }
+                            // An optional never legitimately spans an
+                            // environment, so for the bracket family either half
+                            // is a runaway `[` and there is nothing to count
+                            // ([`EnvAnchor`]).
+                            if P::ENV_ANCHOR == EnvAnchor::Refutes {
+                                break;
+                            }
                             envs += 1;
                         } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
+                            if P::ENV_ANCHOR == EnvAnchor::Refutes {
+                                break;
+                            }
                             match P::NESTING {
                                 // The `\end` must find an environment innermost.
                                 // It does not when the entry on top of `pending`
@@ -3939,6 +4182,27 @@ mod tests {
     #[test]
     fn left_right_batch_keeps_shared_frame_openers_linear() {
         let body = |n: usize| format!("$ {}\\right)$\n", "\\left( x ".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+    }
+
+    /// The bracket family's one-closer-at-EOF shapes (`TODO.md`, container
+    /// stack C2.5). A `[` the gate refuses stays an ordinary token the walk
+    /// steps over, so the next command-abutting `[` is asked in turn and a run
+    /// of them re-scanned per opener; the C0 last-`]` bound spans the whole run
+    /// here, so only the batch — one scan whose nested-opener stack *is* the old
+    /// claim countdown — keeps it linear.
+    ///
+    /// [`MacrocodeBracketGate`] has no such shape to pin: it is single-entry by
+    /// policy (its pre-batch scan ran no countdown), so a chunk of `\cmd[`
+    /// openers whose only `]` sits past the frame still scans to the frame per
+    /// opener. Recorded rather than pinned, like the `${` ratchet above.
+    #[test]
+    fn bracket_batch_keeps_shared_frame_openers_linear() {
+        // `bracket_closes_in_text`: command-abutting `[`s, one `]` at EOF.
+        let body = |n: usize| format!("{}]\n", "\\cmd[x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+        // `bracket_closes_before_math_end`: the same run inside one `$…$`.
+        let body = |n: usize| format!("$ {}]$\n", "\\cmd[x ".repeat(n));
         assert_scan_work_linear(&body(200), &body(400));
     }
 

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -315,6 +315,45 @@ impl GatePolicy for ConditionalGate {
     }
 }
 
+/// [`Parser::alias_closer`]'s policy: environment-alias openers pairing with a
+/// closer alias for the *same* target environment (issue #109).
+///
+/// Two divergences from [`ConditionalGate`], both deliberate:
+///
+/// - **No paragraph anchor.** An alias for `itemize` legitimately spans blank
+///   lines, and the body is parsed with [`Parser::parse_block`], which builds
+///   `PARAGRAPH`s inside it. Reading a blank line here would also key layout on
+///   a trivia predicate the formatter does not preserve.
+/// - **Names must match** ([`GatePolicy::pairs`]). Nesting counts *any* alias
+///   opener and *any* alias closer, so `\bea \bce \ece \eea` pairs while the
+///   crossing `\bea \bce \eea \ece` refuses outright instead of letting an
+///   inner walk run past the outer bound.
+///
+/// Both halves are recognized only outside macro code, where `\begin`/`\end`
+/// are plain commands that need not pair (issues #45/#60) — the same filter the
+/// driver applies to its own `\begin`/`\end` counting.
+struct AliasGate;
+
+impl GatePolicy for AliasGate {
+    const PARAGRAPH_ANCHOR: bool = false;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_alias_closer
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.alias_openers.contains_key(&i) && !p.in_macro_code(i)
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.alias_closers.contains_key(&i) && !p.in_macro_code(i)
+    }
+
+    fn pairs(&self, p: &Parser<'_>, opener: usize, closer: usize) -> bool {
+        p.alias_closers.get(&closer) == p.alias_openers.get(&opener)
+    }
+}
+
 struct Parser<'t> {
     tokens: &'t [Token],
     /// User-defined verbatim constructs, consulted to route a verbatim environment to
@@ -491,13 +530,12 @@ struct Parser<'t> {
     /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
     /// hard-coded special cases). `Cell` because the gates take `&self`.
     scan_work: std::cell::Cell<usize>,
-    /// One-entry memo for [`Self::alias_closer`], as `(opener, group_depth,
-    /// verdict)`. Both [`Self::starts_block_env`] and the [`Self::element`]
-    /// dispatch ask about the same opener at the same cursor position, and the
-    /// walk is the expensive part, so without this every opener pays for it twice.
-    /// Keyed on `group_depth` as well because the verdict reads it; the parser
-    /// never revisits a token index, so one entry is all the reuse there is.
-    alias_closer_memo: std::cell::Cell<Option<(usize, usize, Option<usize>)>>,
+    /// The [`AliasGate`] twin of [`Self::conditional_batch`]. Both
+    /// [`Self::starts_block_env`] and the [`Self::element`] dispatch ask about
+    /// the same opener at the same cursor position, so even before the batch
+    /// settled its neighbors this slot was load-bearing: without it every
+    /// opener paid for its walk twice.
+    alias_batch: std::cell::RefCell<Option<GateBatch>>,
     /// Token index of the alias closer bounding the environment body currently
     /// being parsed, if any. Saved and restored around the body in
     /// [`Self::alias_environment`]. An alias environment has no `\end{…}` to stop
@@ -645,7 +683,7 @@ impl<'t> Parser<'t> {
             scan_work: std::cell::Cell::new(0),
             alias_openers,
             alias_closers,
-            alias_closer_memo: std::cell::Cell::new(None),
+            alias_batch: std::cell::RefCell::new(None),
             alias_end: None,
         }
     }
@@ -3025,112 +3063,29 @@ impl<'t> Parser<'t> {
     /// "pair unless refuted" would be far too optimistic: it must be refused unless
     /// its closer is positively located, and the walk is then bounded by that index.
     ///
-    /// Requirements carried over from the sibling gates:
+    /// Requirements the driver ([`Self::gate_batch`]) carries for it, shared
+    /// with the sibling gates:
     ///
     /// - **Brace level.** A `}` closing a group opened before the opener always
     ///   wins — braces are catcode structure, an alias is only a macro (issue #71).
     /// - **`envs == 0`.** A closer inside an environment the alias opened is
     ///   consumed by that environment's body, so the walk cannot reach it.
-    /// - **Math refuses.** This scan does not model the `$`/`\[`/`\(` shape gates,
+    /// - **Math refuses.** The scan does not model the `$`/`\[`/`\(` shape gates,
     ///   so rather than re-derive them it declines behind one.
     /// - **`macrocode` bounds it both ways**, as for conditionals.
     ///
-    /// Unlike the conditional gate there is deliberately **no paragraph-break
-    /// anchor**: an alias for `itemize` legitimately spans blank lines, and the body
-    /// is parsed with [`Self::parse_block`], which builds `PARAGRAPH`s inside it.
-    /// Reading a blank line here would also key layout on a trivia predicate the
-    /// formatter does not preserve.
+    /// What is this gate's own is in [`AliasGate`]: no paragraph anchor, and a
+    /// closer that must name the opener's target.
     ///
-    /// Nesting counts *any* alias opener and *any* alias closer, then requires the
-    /// closer found at depth zero to name our own target. So `\bea \bce \ece \eea`
-    /// pairs while the crossing `\bea \bce \eea \ece` refuses outright, instead of
-    /// letting an inner walk run past the outer bound.
-    ///
-    /// Memoized, since the caller asks twice — see [`Self::alias_closer_memo`].
+    /// Batched and memoized like the conditional gate — and here the memo was
+    /// load-bearing before the batch existed, since the caller asks twice
+    /// ([`Self::alias_batch`]).
     fn alias_closer(&self, open: usize) -> Option<usize> {
-        if let Some((memo_open, memo_depth, verdict)) = self.alias_closer_memo.get()
-            && memo_open == open
-            && memo_depth == self.group_depth
-        {
-            return verdict;
-        }
-        let verdict = self.alias_closer_uncached(open);
-        self.alias_closer_memo
-            .set(Some((open, self.group_depth, verdict)));
-        verdict
-    }
-
-    /// [`Self::alias_closer`]'s walk, behind that method's memo.
-    fn alias_closer_uncached(&self, open: usize) -> Option<usize> {
-        let target = self.alias_openers.get(&open)?;
-        let mut depth = 0usize;
-        let mut envs = 0usize;
-        let mut nested = 0usize;
-        // Every `Some` return names an index in `alias_closers`, so the walk can
-        // stop at the last one in the file: past it only `None` paths remain, and
-        // running off the end is `None` too. Without the bound, a file of openers
-        // that never pair (`\bc` per line, no `\ec` anywhere) walks each one to
-        // EOF — quadratic, and measurably so on a `.sty` of a few thousand lines.
-        let end = self
-            .macrocode_end
-            .unwrap_or(self.tokens.len())
-            .min(self.tokens.len())
-            .min(self.last_alias_closer? + 1);
-        let mut i = open + 1;
-        while i < end {
-            self.tick_scan();
-            let t = &self.tokens[i];
-            match t.kind {
-                SyntaxKind::DOLLAR if depth == 0 => return None,
-                SyntaxKind::CONTROL_SYMBOL
-                    if depth == 0 && matches!(t.text.as_str(), "\\[" | "\\(") =>
-                {
-                    return None;
-                }
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
-                    if depth == 0 {
-                        if self.group_depth > 0 {
-                            return None;
-                        }
-                    } else {
-                        depth -= 1;
-                    }
-                }
-                SyntaxKind::CONTROL_WORD if depth == 0 && !self.in_macro_code(i) => {
-                    if self.alias_openers.contains_key(&i) {
-                        nested += 1;
-                    } else if let Some(closing) = self.alias_closers.get(&i) {
-                        if nested == 0 {
-                            // Ours only if it names the same environment and no
-                            // `\begin`-opened environment stands in the way.
-                            return (closing == target && envs == 0).then_some(i);
-                        }
-                        nested -= 1;
-                    } else if t.text.as_str() == BEGIN_CMD && self.env_name_follows(i) {
-                        // A `macrocode` frame is a hard boundary in both directions,
-                        // for the reason spelled out in `conditional_closer`.
-                        if peek_begin_name(self.tokens, i)
-                            .is_some_and(|n| matches!(n.as_str(), "macrocode" | "macrocode*"))
-                        {
-                            return None;
-                        }
-                        envs += 1;
-                    } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                        if envs == 0 {
-                            return None;
-                        }
-                        envs -= 1;
-                    }
-                }
-                _ => {}
-            }
-            i += 1;
-        }
-        // Running out of input does not pair: unlike `\begin`, there is no
-        // unclosed-environment diagnostic to preserve, so a lone opener is simply
-        // a macro call.
-        None
+        // Total in `open`: [`Self::starts_block_env`] asks about any index, and
+        // the driver would otherwise seed an entry for a token that opens
+        // nothing.
+        self.alias_openers.get(&open)?;
+        self.gated_closer(open, &AliasGate, &self.alias_batch)
     }
 
     /// `\bea … \eea`: an environment opened and closed by bare control words, for
@@ -3681,6 +3636,29 @@ mod tests {
     fn conditional_batch_keeps_shared_frame_openers_linear() {
         let body = |n: usize| format!("{}\\fi\n", "\\ifabc x\n".repeat(n));
         assert_scan_work_linear(&body(200), &body(400));
+    }
+
+    /// The alias twin of `conditional_batch_keeps_shared_frame_openers_linear`
+    /// (`TODO.md`, container stack C2.1): a run of same-frame alias openers
+    /// whose lone closer sits at EOF spans the whole file, so the C0
+    /// last-closer bound cuts nothing and only the batch keeps it linear.
+    #[test]
+    fn alias_batch_keeps_shared_frame_openers_linear() {
+        let scan_work = |input: &str| {
+            let tokens = lex(input);
+            let mut ctx = ParseCtx::default();
+            ctx.insert_begin_alias(SmolStr::new("bc"), SmolStr::new("center"));
+            ctx.insert_end_alias(SmolStr::new("ec"), SmolStr::new("center"));
+            let mut p = Parser::new(&tokens, &ctx);
+            p.document();
+            p.scan_work.get()
+        };
+        let body = |n: usize| format!("{}\\ec\n", "\\bc x\n".repeat(n));
+        let (w1, w2) = (scan_work(&body(200)), scan_work(&body(400)));
+        assert!(
+            w2 < 3 * w1 + 64,
+            "gate-scan work grew superlinearly: {w1} -> {w2}"
+        );
     }
 
     /// The in-math no-closer shapes: the enclosing math's own gate passes (its

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -357,6 +357,37 @@ struct Parser<'t> {
     /// index in that map, so this bounds its forward scan — which is what keeps
     /// a file of openers that never pair linear instead of quadratic.
     last_alias_closer: Option<usize>,
+    /// The `last_alias_closer` treatment, generalized (`TODO.md`, container
+    /// stack C0): each shape gate succeeds only at one closer token shape, so
+    /// truncating its scan at the last occurrence of that shape is
+    /// verdict-preserving — past it, every path is a refusal, whether by anchor
+    /// or by running out of range — and a file with none refuses without
+    /// scanning at all. Recording may *over*-approximate (a `\fi` inside an
+    /// expl3 region, a `\right` inside a brace group): a bound only needs to be
+    /// at or past the last index that could ever succeed.
+    ///
+    /// This one is the last `]`, bounding [`Self::bracket_closes_in_text`] and
+    /// [`Self::bracket_closes_before_math_end`].
+    last_r_bracket: Option<usize>,
+    /// Last `\]` — bounds [`Self::delim_math_closes`] for a `\[` opener.
+    last_display_math_closer: Option<usize>,
+    /// Last `\)` — bounds [`Self::delim_math_closes`] for a `\(` opener.
+    last_inline_math_closer: Option<usize>,
+    /// Last `\right` — bounds [`Self::left_right_closes`].
+    last_right: Option<usize>,
+    /// Last `}` — bounds [`Self::environment_escapes_group`], whose only `true`
+    /// is a `}` at depth 0. Rarely effective (every `\begin{…}` opener carries a
+    /// `}` in its own name group, so this index usually sits near EOF), but
+    /// sound and free; the gate's residual quadratic shape is recorded in
+    /// `TODO.md` (container stack, C2).
+    last_r_brace: Option<usize>,
+    /// Last `\fi`-flavored flow word — bounds [`Self::conditional_closer`].
+    last_fi: Option<usize>,
+    /// Tokens visited by the shape-gate scans, summed over the whole parse. A
+    /// measurement hook for the linearity regression tests in this file's
+    /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
+    /// hard-coded special cases). `Cell` because the gates take `&self`.
+    scan_work: std::cell::Cell<usize>,
     /// One-entry memo for [`Self::alias_closer`], as `(opener, group_depth,
     /// verdict)`. Both [`Self::starts_block_env`] and the [`Self::element`]
     /// dispatch ask about the same opener at the same cursor position, and the
@@ -390,9 +421,41 @@ impl<'t> Parser<'t> {
         // keyword rather than calls — a countdown, since `\let\a\b` binds two. See
         // [`Self::alias_openers`] for why this filter is mandatory.
         let mut def_name_slots = 0u8;
+        let mut last_r_bracket = None;
+        let mut last_display_math_closer = None;
+        let mut last_inline_math_closer = None;
+        let mut last_right = None;
+        let mut last_r_brace = None;
+        let mut last_fi = None;
         for (i, t) in tokens.iter().enumerate() {
             starts.push(off);
             off += t.text.len();
+            // Last-closer indices for the gate bounds ([`Self::last_r_bracket`]),
+            // recorded before the control-word early-out below so the
+            // non-control-word shapes are seen. `\fi` recognition deliberately
+            // skips the expl3-region filter [`Self::conditional_flow_at`]
+            // applies: an upper bound only needs to be at or past the last
+            // viable index, and keeping the recording filter-free means it can
+            // never drift *below* the gate's recognition.
+            match t.kind {
+                SyntaxKind::R_BRACKET => last_r_bracket = Some(i),
+                SyntaxKind::R_BRACE => last_r_brace = Some(i),
+                SyntaxKind::CONTROL_SYMBOL => match t.text.as_str() {
+                    "\\]" => last_display_math_closer = Some(i),
+                    "\\)" => last_inline_math_closer = Some(i),
+                    _ => {}
+                },
+                SyntaxKind::CONTROL_WORD => {
+                    if t.text.as_str() == RIGHT_CMD {
+                        last_right = Some(i);
+                    } else if t.text.strip_prefix('\\').and_then(conditional::flow_word)
+                        == Some(conditional::FlowWord::Fi)
+                    {
+                        last_fi = Some(i);
+                    }
+                }
+                _ => {}
+            }
             if t.kind != SyntaxKind::CONTROL_WORD {
                 // Trivia carries the definition-keyword state across (`\def  \bea`);
                 // anything else clears it.
@@ -468,6 +531,13 @@ impl<'t> Parser<'t> {
             expl_toggles,
             conditional_openers,
             last_alias_closer: alias_closers.keys().copied().max(),
+            last_r_bracket,
+            last_display_math_closer,
+            last_inline_math_closer,
+            last_right,
+            last_r_brace,
+            last_fi,
+            scan_work: std::cell::Cell::new(0),
             alias_openers,
             alias_closers,
             alias_closer_memo: std::cell::Cell::new(None),
@@ -1480,6 +1550,11 @@ impl<'t> Parser<'t> {
     /// over several lines still attaches on the second pass. Keeps a code
     /// bracket (`\@tempcnta[` with no `]` in the chunk) an ordinary token
     /// instead of an optional that would swallow the frame.
+    /// One tick per token a shape-gate scan visits, into [`Self::scan_work`].
+    fn tick_scan(&self) {
+        self.scan_work.set(self.scan_work.get() + 1);
+    }
+
     fn bracket_closes_before_macrocode_end(&self, open: usize) -> bool {
         let Some(end) = self.macrocode_end else {
             return true;
@@ -1490,6 +1565,7 @@ impl<'t> Parser<'t> {
             .iter()
             .enumerate()
         {
+            self.tick_scan();
             let idx = open + 1 + off;
             match t.kind {
                 SyntaxKind::NEWLINE => {
@@ -1549,12 +1625,20 @@ impl<'t> Parser<'t> {
     ///   it. Does not consume.
     fn bracket_closes_before_math_end(&self, open: usize) -> bool {
         let enclosing_is_dollar = self.math_dollar.last().copied().unwrap_or(false);
+        // Every `true` is at an `R_BRACKET`, so the scan is bounded by the last
+        // one in the file ([`Self::last_r_bracket`]); with none past the opener
+        // it refuses outright. Without the bound, a math body of `\cmd[` atoms
+        // with no `]` anywhere scanned each one to its math's end — quadratic.
+        let Some(last) = self.last_r_bracket.filter(|&last| last > open) else {
+            return false;
+        };
         let mut depth = 0usize;
         let mut brackets = 0usize;
         let mut in_inline = false;
         let mut newlines = 0;
         let mut abuts_command = false;
-        for (off, t) in self.tokens[open + 1..].iter().enumerate() {
+        for (off, t) in self.tokens[open + 1..=last].iter().enumerate() {
+            self.tick_scan();
             let idx = open + 1 + off;
             let prev_abuts_command = abuts_command;
             abuts_command = false;
@@ -1622,11 +1706,20 @@ impl<'t> Parser<'t> {
     /// stays an ordinary token with **no diagnostic**: in code the shape is
     /// routine, so it is not statically an error. Does not consume.
     fn bracket_closes_in_text(&self, open: usize) -> bool {
+        // Bounded by the last `]` in the file ([`Self::last_r_bracket`]), the
+        // `last_alias_closer` treatment: past it only refusals remain, and with
+        // none past the opener the gate refuses without scanning. Without the
+        // bound, a file of `\cmd[` lines with no `]` and no blank line scanned
+        // each opener to EOF — quadratic (`TODO.md`, container stack C0).
+        let Some(last) = self.last_r_bracket.filter(|&last| last > open) else {
+            return false;
+        };
         let mut depth = 0usize;
         let mut brackets = 0usize;
         let mut newlines = 0;
         let mut abuts_command = false;
-        for (off, t) in self.tokens[open + 1..].iter().enumerate() {
+        for (off, t) in self.tokens[open + 1..=last].iter().enumerate() {
+            self.tick_scan();
             let idx = open + 1 + off;
             let prev_abuts_command = abuts_command;
             abuts_command = false;
@@ -1701,6 +1794,12 @@ impl<'t> Parser<'t> {
     /// `\begin`/`\end` are plain commands (issue #45), so neither anchors nor
     /// nests there. Does not consume.
     fn dollar_closes(&self, open: usize, display: bool) -> bool {
+        // The one gate with no last-closer bound: its closer (`DOLLAR`) is its
+        // opener's own token kind, so the last one in a file of openers is just
+        // the final opener — the bound would be vacuous. The residual
+        // adversarial shape (a `${` per line: depth ratchets upward, so the
+        // level-gated paragraph anchor never fires and no depth-0 `$` ever
+        // appears) is recorded in `TODO.md` (container stack, C2).
         let mut depth = 0usize;
         let mut envs = 0usize;
         let mut newlines = 0;
@@ -1711,6 +1810,7 @@ impl<'t> Parser<'t> {
             .min(self.tokens.len());
         let mut i = start;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             match t.kind {
                 SyntaxKind::NEWLINE => {
@@ -1771,15 +1871,30 @@ impl<'t> Parser<'t> {
     /// paragraph break blocks only at the math body's own level
     /// ([`Self::paragraph_break_blocks`]).
     fn delim_math_closes(&self, open: usize, closer: &str) -> bool {
+        // Bounded by the last occurrence of *this* closer in the file (the
+        // `last_alias_closer` treatment): every `true` is at one, so past it
+        // only refusals remain, and a file with none refuses without scanning.
+        // Without the bound, a non-`.dtx` file of `\[` openers with no closer
+        // and no blank line scanned each one to EOF — quadratic (`TODO.md`,
+        // container stack C0).
+        let last = match closer {
+            "\\]" => self.last_display_math_closer,
+            _ => self.last_inline_math_closer,
+        };
+        let Some(last) = last else {
+            return false;
+        };
         let mut depth = 0usize;
         let mut envs = 0usize;
         let mut newlines = 0;
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
-            .min(self.tokens.len());
+            .min(self.tokens.len())
+            .min(last + 1);
         let mut i = open + 1;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             match t.kind {
                 SyntaxKind::NEWLINE => {
@@ -1845,12 +1960,25 @@ impl<'t> Parser<'t> {
         }
         let mut stack: Vec<Ctx> = Vec::new();
         let mut newlines = 0;
+        // Bounded by the last `\right` in the file ([`Self::last_right`], the
+        // `last_alias_closer` treatment): every `true` is at one, so past it
+        // only refusals remain, and a file with none refuses without scanning.
+        // The recording ignores brace nesting (a `\right` inside a `{…}` group
+        // is invisible to this scan), which only ever places the bound *past*
+        // the last viable closer. Without it, a math body of `\left` openers
+        // with no `\right` kept the stack non-empty — so the blank-line anchor
+        // never fired — and scanned each opener to the math's end: quadratic.
+        let Some(last) = self.last_right else {
+            return false;
+        };
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
-            .min(self.tokens.len());
+            .min(self.tokens.len())
+            .min(last + 1);
         let mut i = open + 1;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             // A brace group parses as [`Self::math_group`]: only its own braces
             // steer nesting; every other token inside it is ordinary content
@@ -2409,14 +2537,24 @@ impl<'t> Parser<'t> {
         if self.doc_margin_exempt(open) {
             return false;
         }
+        // The only `true` is a `}` at depth 0, so the last `}` in the file
+        // bounds the scan ([`Self::last_r_brace`]) — sound, but rarely
+        // effective, since a `\begin{…}` opener's own name group carries a `}`
+        // and pushes the index toward EOF. The gate's residual quadratic shape
+        // is recorded in `TODO.md` (container stack, C2).
+        let Some(last) = self.last_r_brace else {
+            return false;
+        };
         let mut depth = 0usize;
         let mut envs = 0usize;
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
-            .min(self.tokens.len());
+            .min(self.tokens.len())
+            .min(last + 1);
         let mut i = open + 1;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             match t.kind {
                 // The `{name}` group of this very `\begin` nests and unnests
@@ -2503,14 +2641,21 @@ impl<'t> Parser<'t> {
     /// and why nothing downstream may assume the two indices agree
     /// (`conditional_walk_may_close_before_the_located_fi`, `tests/parser.rs`).
     ///
-    /// **Cost.** One forward scan per live opener, so O(n·openers) worst case. Every
-    /// ordinary anchor cuts it short, which is why real conditional-heavy packages
-    /// show no measurable change (`biblatex.sty`, `latexrelease.sty`, `memoir.cls`
-    /// all within noise of the pre-node parser). The shape that does not cut short is
-    /// thousands of *top-level* openers with no blank line, no unbalanced brace, and
-    /// no reachable `\fi`: 8000 such lines cost ~2s against ~0.07s. No real corpus
-    /// file hits it; see `TODO.md` for the linear rewrite if one ever does.
+    /// **Cost.** One forward scan per live opener, bounded by the last
+    /// `\fi`-flavored flow word in the file ([`Self::last_fi`], the
+    /// `last_alias_closer` treatment): every `Some` is at one, so past it only
+    /// refusals remain, and a file with none refuses without scanning — which
+    /// is what keeps the measured pathological shape (thousands of *top-level*
+    /// openers with no blank line, no unbalanced brace, and no `\fi` at all;
+    /// 8000 such lines cost ~2s against ~0.07s unbounded) linear. Every
+    /// ordinary anchor still cuts a scan short, which is why real
+    /// conditional-heavy packages show no measurable change (`biblatex.sty`,
+    /// `latexrelease.sty`, `memoir.cls` all within noise of the pre-node
+    /// parser). The residual shape — those same openers with one `\fi` at EOF —
+    /// stays O(n·openers); see `TODO.md` (container stack, C1) for the batched
+    /// rewrite.
     fn conditional_closer(&self, open: usize) -> Option<usize> {
+        let last_fi = self.last_fi?;
         let mut depth = 0usize;
         let mut envs = 0usize;
         let mut nested = 0usize;
@@ -2518,9 +2663,11 @@ impl<'t> Parser<'t> {
         let end = self
             .macrocode_end
             .unwrap_or(self.tokens.len())
-            .min(self.tokens.len());
+            .min(self.tokens.len())
+            .min(last_fi + 1);
         let mut i = open + 1;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             match t.kind {
                 SyntaxKind::NEWLINE => {
@@ -2679,6 +2826,7 @@ impl<'t> Parser<'t> {
             .min(self.last_alias_closer? + 1);
         let mut i = open + 1;
         while i < end {
+            self.tick_scan();
             let t = &self.tokens[i];
             match t.kind {
                 SyntaxKind::DOLLAR if depth == 0 => return None,
@@ -3230,5 +3378,60 @@ mod tests {
         p.pos += 1;
         p.step();
         assert_eq!(p.steps.get(), 1, "progress should reset the peek budget");
+    }
+
+    /// Drive a full parse and return how many tokens the shape-gate scans
+    /// visited ([`Parser::scan_work`]).
+    fn scan_work(input: &str) -> usize {
+        let tokens = lex(input);
+        let ctx = ParseCtx::default();
+        let mut p = Parser::new(&tokens, &ctx);
+        p.document();
+        p.scan_work.get()
+    }
+
+    /// Doubling the input must not blow the gate-scan work up quadratically:
+    /// `3·work(N)` leaves room for per-parse constants while a quadratic gate
+    /// (ratio 4 per doubling) still fails loudly. The slack constant absorbs
+    /// shapes whose bounded work is near zero.
+    #[track_caller]
+    fn assert_scan_work_linear(small: &str, doubled: &str) {
+        let (w1, w2) = (scan_work(small), scan_work(doubled));
+        assert!(
+            w2 < 3 * w1 + 64,
+            "gate-scan work grew superlinearly: {w1} -> {w2}"
+        );
+    }
+
+    /// The adversarial no-closer shapes (`TODO.md`, container stack C0): a file
+    /// of openers whose gate can never succeed must refuse via its absent
+    /// last-closer bound instead of scanning forward per opener.
+    #[test]
+    fn gate_scans_stay_linear_without_closers() {
+        // `conditional_closer`: `\if`-prefixed openers, no `\fi` anywhere.
+        let shape = "\\ifabc x\n";
+        assert_scan_work_linear(&shape.repeat(200), &shape.repeat(400));
+        // `bracket_closes_in_text`: command-abutting `[`s, no `]` anywhere.
+        let shape = "\\cmd[x\n";
+        assert_scan_work_linear(&shape.repeat(200), &shape.repeat(400));
+        // `delim_math_closes`: display-math openers, no `\]` anywhere.
+        let shape = "\\[ x\n";
+        assert_scan_work_linear(&shape.repeat(200), &shape.repeat(400));
+    }
+
+    /// The in-math no-closer shapes: the enclosing math's own gate passes (its
+    /// closer is reachable), and every opener inside it must still refuse
+    /// without a per-opener scan to the math's end.
+    #[test]
+    fn math_gate_scans_stay_linear_without_closers() {
+        // `bracket_closes_before_math_end`: `\cmd[` atoms in dollar math, no
+        // `]` anywhere.
+        let body = |n: usize| format!("$ {}$", "\\cmd[x ".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+        // `left_right_closes`: `\left` openers in display math, no `\right`
+        // anywhere — the pair stack stays non-empty, so the blank-line anchor
+        // alone never cuts the scan.
+        let body = |n: usize| format!("\\[\n{}\\]\n", "\\left( x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
     }
 }

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -464,9 +464,11 @@ trait GatePolicy {
     const NESTING: Nesting = Nesting::Counted;
 
     /// Whether this gate's openers are themselves `\begin`s, so the driver must
-    /// count one in `envs` *before* pushing its entry. An entry's `envs_at_push`
-    /// then excludes its own environment — which its per-opener scan, starting
-    /// one token past the `\begin`, never saw either.
+    /// count one in `envs` *before* pushing its entry. The entry's own
+    /// environment is therefore *in* its `envs_at_push`, which is what makes the
+    /// relative count `envs - envs_at_push` start at zero — matching its
+    /// per-opener scan, which starts one token past the `\begin` and never saw
+    /// that environment either.
     const OPENER_IS_ENV_BEGIN: bool = false;
 
     /// Whether the `\begin`/`\end` and math-*delimiter* anchors apply at any
@@ -914,6 +916,15 @@ impl GatePolicy for TextBracketGate {
 ///   not plain tokens ([`GatePolicy::PLAIN_BRACES_ARE_TOKENS`]). Both make it
 ///   stricter than the [`Parser::optional`] bail it mirrors, in the direction
 ///   that only ever declines to attach.
+///
+/// This is also the one gate whose `macrocode` bound is not the C0 argument.
+/// Every other gate's pre-batch scan already stopped at [`Parser::macrocode_end`];
+/// this one ran to EOF, so the driver's frame bound is new to it, and "past the
+/// last closer only refusals remain" is not why it is verdict-preserving. The
+/// reason is the bullet above: the `\begin`/`\end` anchor here carries no
+/// `in_macro_code` filter, and the token at `macrocode_end` is the frame's own
+/// `\end{macrocode}`, which the anchor refuses at — so the pre-batch scan
+/// stopped at exactly the index the bound now stops before.
 struct MathBracketGate {
     /// Whether the innermost enclosing math is `$…$`/`$$…$$`
     /// ([`Parser::math_dollar`]).
@@ -1165,9 +1176,9 @@ struct Parser<'t> {
     /// settled by the batch; anything else re-batches from the queried opener.
     /// One slot is all the reuse there is: [`Self::element`] queries each
     /// opener once, in ascending order, under a stable state between
-    /// re-batches. `RefCell` because the gate is `&self` (the
-    /// [`Self::alias_closer_memo`] pattern, with a map where that memo keeps
-    /// one verdict).
+    /// re-batches. `RefCell` because the gate is `&self` — the pattern the
+    /// alias gate's pre-batch memo used, with a map of settled openers where
+    /// that one kept a single verdict.
     conditional_batch: std::cell::RefCell<Option<GateBatch>>,
     /// Tokens visited by the shape-gate scans, summed over the whole parse. A
     /// measurement hook for the linearity regression tests in this file's

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -253,6 +253,21 @@ struct GateBatch {
     verdicts: std::collections::HashMap<usize, Option<usize>>,
 }
 
+/// What a `}` closing a group opened *before* a gate's entries means to that
+/// gate. The token event is the same for every gate — braces are catcode
+/// structure while the gated delimiters are only macros, so the `}` always wins
+/// — but the *verdict* it implies is opposite either side of the positive
+/// gate/demotion gate line, which is why it is policy and not bookkeeping.
+#[derive(PartialEq, Eq)]
+enum StrayBrace {
+    /// It refutes every live entry: a conditional or an alias cannot pair
+    /// across it, so the opener stays a plain command.
+    Refutes,
+    /// It *is* the closer: [`Parser::environment_escapes_group`] asks whether
+    /// the `\begin` escapes its group, and this brace is the escape.
+    Closes,
+}
+
 /// The per-gate half of [`Parser::gate_batch`]: how far this gate's scan can
 /// reach, which tokens open and close its construct, and whether a blank line
 /// anchors it.
@@ -274,6 +289,26 @@ trait GatePolicy {
     /// conditionals, which mirror a parse that stops at a `\par`; false for
     /// aliases, whose body legitimately spans blank lines.
     const PARAGRAPH_ANCHOR: bool;
+
+    /// What a `}` closing a group opened *before* the entries means. Defaults
+    /// to the *positive* gates' reading; see [`StrayBrace`].
+    const STRAY_BRACE: StrayBrace = StrayBrace::Refutes;
+
+    /// Whether a math delimiter at the entries' own level refutes them.
+    ///
+    /// True for the positive gates: the scan does not model the `$`/`\[`/`\(`
+    /// shape gates, and declining to pair behind one is the conservative
+    /// direction for a construct that only pairs when positively located. A
+    /// *demotion* gate inverts that — refusing there would keep a construct the
+    /// scan cannot vouch for — so `EnvGate` sets this false and reads math as
+    /// ordinary content, exactly as its pre-batch scan did.
+    const MATH_REFUTES: bool = true;
+
+    /// Whether this gate's openers are themselves `\begin`s, so the driver must
+    /// count one in `envs` *before* pushing its entry. An entry's `envs_at_push`
+    /// then excludes its own environment — which its per-opener scan, starting
+    /// one token past the `\begin`, never saw either.
+    const OPENER_IS_ENV_BEGIN: bool = false;
 
     /// The last index in the file that could ever settle an entry with a
     /// closer — the C0 bound. `None` refuses the whole gate without scanning.
@@ -351,6 +386,50 @@ impl GatePolicy for AliasGate {
 
     fn pairs(&self, p: &Parser<'_>, opener: usize, closer: usize) -> bool {
         p.alias_closers.get(&closer) == p.alias_openers.get(&opener)
+    }
+}
+
+/// [`Parser::environment_escapes_group`]'s policy, and the driver's first
+/// *demotion* gate: it asks whether a `\begin` is cut short by the closing brace
+/// of a group it sits inside, so a located "closer" is the escaping `}` and the
+/// verdict reads inverted — `Some` demotes the environment, `None` keeps it.
+///
+/// Three divergences from the positive gates, all following from that
+/// inversion:
+///
+/// - **The stray `}` closes rather than refutes** ([`StrayBrace::Closes`]).
+///   Same token event, opposite verdict.
+/// - **Math does not refuse** ([`GatePolicy::MATH_REFUTES`]). For a positive
+///   gate, declining behind a math delimiter is the conservative direction; for
+///   this one it would *keep* an environment the scan cannot vouch for. The
+///   pre-batch scan had no math anchor, and this preserves that.
+/// - **Openers are `\begin`s** ([`GatePolicy::OPENER_IS_ENV_BEGIN`]), so the
+///   driver counts one in `envs` before pushing its entry.
+///
+/// `\end` is deliberately *not* a closer here: it is the level anchor the
+/// driver already applies (an `\end` not owed to an intervening `\begin` means
+/// this environment ends before any group boundary, so it does not escape),
+/// which leaves the mismatch recovery in [`Parser::finish_environment`]
+/// untouched. Running out of file is likewise not an escape — that is what
+/// keeps the unclosed-environment diagnostic firing on a forgotten `\end`.
+struct EnvGate;
+
+impl GatePolicy for EnvGate {
+    const PARAGRAPH_ANCHOR: bool = false;
+    const STRAY_BRACE: StrayBrace = StrayBrace::Closes;
+    const MATH_REFUTES: bool = false;
+    const OPENER_IS_ENV_BEGIN: bool = true;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_r_brace
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.tokens[i].text == BEGIN_CMD && p.env_name_follows(i) && !p.in_macro_code(i)
+    }
+
+    fn closes_at(&self, _p: &Parser<'_>, _i: usize) -> bool {
+        false
     }
 }
 
@@ -530,6 +609,11 @@ struct Parser<'t> {
     /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
     /// hard-coded special cases). `Cell` because the gates take `&self`.
     scan_work: std::cell::Cell<usize>,
+    /// The [`EnvGate`] twin of [`Self::conditional_batch`]. Its verdicts are
+    /// the *scan's* alone: [`Self::environment_escapes_group`]'s per-opener
+    /// pre-checks (`group_depth`, the `.dtx` doc-margin exemption) are applied
+    /// at query time, so a batch entry never carries them.
+    env_batch: std::cell::RefCell<Option<GateBatch>>,
     /// The [`AliasGate`] twin of [`Self::conditional_batch`]. Both
     /// [`Self::starts_block_env`] and the [`Self::element`] dispatch ask about
     /// the same opener at the same cursor position, so even before the batch
@@ -684,6 +768,7 @@ impl<'t> Parser<'t> {
             alias_openers,
             alias_closers,
             alias_batch: std::cell::RefCell::new(None),
+            env_batch: std::cell::RefCell::new(None),
             alias_end: None,
         }
     }
@@ -2680,50 +2765,19 @@ impl<'t> Parser<'t> {
         if self.doc_margin_exempt(open) {
             return false;
         }
-        // The only `true` is a `}` at depth 0, so the last `}` in the file
-        // bounds the scan ([`Self::last_r_brace`]) — sound, but rarely
-        // effective, since a `\begin{…}` opener's own name group carries a `}`
-        // and pushes the index toward EOF. The gate's residual quadratic shape
-        // is recorded in `TODO.md` (container stack, C2).
-        let Some(last) = self.last_r_brace else {
-            return false;
-        };
-        let mut depth = 0usize;
-        let mut envs = 0usize;
-        let end = self
-            .macrocode_end
-            .unwrap_or(self.tokens.len())
-            .min(self.tokens.len())
-            .min(last + 1);
-        let mut i = open + 1;
-        while i < end {
-            self.tick_scan();
-            let t = &self.tokens[i];
-            match t.kind {
-                // The `{name}` group of this very `\begin` nests and unnests
-                // here, so the scan resumes at the environment's own level.
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
-                    if depth == 0 {
-                        return true;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::CONTROL_WORD if depth == 0 && !self.in_macro_code(i) => {
-                    if t.text.as_str() == BEGIN_CMD && self.env_name_follows(i) {
-                        envs += 1;
-                    } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                        if envs == 0 {
-                            return false;
-                        }
-                        envs -= 1;
-                    }
-                }
-                _ => {}
-            }
-            i += 1;
-        }
-        false
+        // Both checks above are per-opener walk state, so they stay outside the
+        // batch: a `\begin` they reject never consults it, and the batch stores
+        // only what the *scan* decided.
+        //
+        // The `{name}` group of the `\begin` itself nests and unnests inside the
+        // scan, so it resumes at the environment's own level. The only escape is
+        // a `}` at that level, so the last `}` in the file bounds the scan
+        // ([`Self::last_r_brace`]) — sound, but rarely effective, since a
+        // `\begin{…}` opener's own name group carries one and pushes the index
+        // toward EOF. That is why this gate needed the batch
+        // ([`EnvGate`], `TODO.md` container stack C2.2): the bound alone left it
+        // quadratic in the number of openers.
+        self.gated_closer(open, &EnvGate, &self.env_batch).is_some()
     }
 
     /// The conditional twin of [`Self::delim_math_closes`]: whether the live
@@ -2952,13 +3006,16 @@ impl<'t> Parser<'t> {
                 }
                 // Math swallows whatever it spans, and this scan does not model
                 // the `$`/`\[`/`\(` shape gates that decide whether a delimiter
-                // opens any. Rather than re-derive them, refuse: a construct
-                // whose closer sits behind a math delimiter stays a plain command.
-                // A conservative false negative, per the parser's standing
-                // preference for them.
-                SyntaxKind::DOLLAR if depth == 0 => break,
+                // opens any. Rather than re-derive them, the positive gates
+                // refuse: a construct whose closer sits behind a math delimiter
+                // stays a plain command. A conservative false negative, per the
+                // parser's standing preference for them — and the direction a
+                // demotion gate reverses ([`GatePolicy::MATH_REFUTES`]).
+                SyntaxKind::DOLLAR if depth == 0 && P::MATH_REFUTES => break,
                 SyntaxKind::CONTROL_SYMBOL
-                    if depth == 0 && matches!(t.text.as_str(), "\\[" | "\\(") =>
+                    if depth == 0
+                        && P::MATH_REFUTES
+                        && matches!(t.text.as_str(), "\\[" | "\\(") =>
                 {
                     break;
                 }
@@ -2967,12 +3024,24 @@ impl<'t> Parser<'t> {
                     if depth == 0 {
                         // A `}` closing a group opened before the opener always
                         // wins: braces are catcode structure while the gated
-                        // delimiters are only macros. At the outer level there is no such
-                        // group, so a stray `}` is somebody else's business and
-                        // the scan carries on (the `\begin` gate's `group_depth`
-                        // guard, transcribed).
+                        // delimiters are only macros. At the outer level there
+                        // is no such group, so a stray `}` is somebody else's
+                        // business and the scan carries on. What the brace
+                        // *means* is the gate's own call ([`StrayBrace`]).
                         if self.group_depth > 0 {
-                            break;
+                            match P::STRAY_BRACE {
+                                StrayBrace::Refutes => break,
+                                StrayBrace::Closes => {
+                                    // Every live entry escapes at the same
+                                    // brace: `depth` is common to the whole
+                                    // frame, so each one's own scan would reach
+                                    // this `}` at its own depth 0 too.
+                                    for &idx in &live {
+                                        verdicts.insert(pending[idx].opener, Some(i));
+                                    }
+                                    return verdicts;
+                                }
+                            }
                         }
                     } else {
                         depth -= 1;
@@ -2980,6 +3049,13 @@ impl<'t> Parser<'t> {
                 }
                 SyntaxKind::CONTROL_WORD if depth == 0 => {
                     if policy.opens_at(self, i) {
+                        // A gate whose openers are `\begin`s counts this one
+                        // before pushing, so the entry's own environment is not
+                        // in its `envs_at_push` — its per-opener scan starts one
+                        // token past the `\begin` and never saw it either.
+                        if P::OPENER_IS_ENV_BEGIN {
+                            envs += 1;
+                        }
                         live.push(pending.len());
                         pending.push(Entry {
                             opener: i,
@@ -3659,6 +3735,16 @@ mod tests {
             w2 < 3 * w1 + 64,
             "gate-scan work grew superlinearly: {w1} -> {w2}"
         );
+    }
+
+    /// The `\begin` gate's own shape (`TODO.md`, container stack C2.2): openers
+    /// inside a group with no `}` of their own. Its C0 bound is the last `}` in
+    /// the file, which every `\begin{…}` name group pushes toward EOF, so the
+    /// bound cuts nothing here and only the batch keeps it linear.
+    #[test]
+    fn env_batch_keeps_shared_frame_openers_linear() {
+        let body = |n: usize| format!("{{\n{}", "\\begin{itemize}\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
     }
 
     /// The in-math no-closer shapes: the enclosing math's own gate passes (its

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -225,21 +225,94 @@ fn debug_assert_balanced(events: &[Event]) {
     );
 }
 
-/// One batched run of the conditional gate's scan
-/// ([`Parser::conditional_closers_from`]): the per-opener verdicts it
-/// harvested, valid under the walk state in `key`.
-struct ConditionalBatch {
-    /// The walk state the scan read: `(macrocode_end, in_def_body,
-    /// group_depth > 0)`. `plain_braces` needs no slot of its own — it is
-    /// saved and restored in lockstep with `macrocode_end` per chunk
-    /// ([`Parser::macrocode_body`]), so pinning the frame pins it; everything
-    /// else the scan reads is pre-scanned token state.
-    key: (Option<usize>, bool, bool),
-    /// Opener index → the verdict [`Parser::conditional_closer`] would have
-    /// computed for it under `key`, for every same-frame opener the scan
-    /// passed. Openers absent from the map sat behind a brace during the
-    /// batch and re-batch when queried.
+/// The walk state a gate batch's scan reads, and therefore the key its
+/// verdicts stay valid under ([`Parser::walk_key`]). Everything else a scan
+/// consults is pre-scanned token state, a pure function of the text.
+///
+/// `plain_braces` rides a version counter rather than the set itself: it is
+/// saved and restored in lockstep with `macrocode_end` per chunk
+/// ([`Parser::macrocode_body`]), so pinning the frame already pins it, but a
+/// counter makes that a fact instead of an argument — and a version can only
+/// ever invalidate a batch the frame index would have kept.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct WalkKey {
+    macrocode_end: Option<usize>,
+    in_def_body: bool,
+    in_group: bool,
+    plain_braces: u32,
+}
+
+/// One batched run of a shape gate's scan ([`Parser::gate_batch`]): the
+/// per-opener verdicts it harvested, valid under the walk state in `key`.
+struct GateBatch {
+    key: WalkKey,
+    /// Opener index → the verdict that opener's own scan would have computed
+    /// under `key`, for every same-frame opener the scan passed. Openers
+    /// absent from the map sat behind a brace during the batch and re-batch
+    /// when queried.
     verdicts: std::collections::HashMap<usize, Option<usize>>,
+}
+
+/// The per-gate half of [`Parser::gate_batch`]: how far this gate's scan can
+/// reach, which tokens open and close its construct, and whether a blank line
+/// anchors it.
+///
+/// The driver owns the bookkeeping every gate shares — the bound, brace depth
+/// under [`Parser::plain_braces`], environment counting, the `macrocode`
+/// frame, the entry stack, the metering — and **never averages the
+/// policies**: where two gates diverge, the divergence is a method here,
+/// spelled out and documented, not a compromise inside the loop (`TODO.md`,
+/// container stack C2).
+///
+/// Hooks arrive with the client that needs them, so the driver stays
+/// *extracted* from C1's working batch rather than authored to a lowest common
+/// denominator. Today every client's delimiters are `CONTROL_WORD`s at the
+/// entries' own brace level, so that is all the driver classifies; the math
+/// and bracket gates widen it when they migrate.
+trait GatePolicy {
+    /// Whether a blank line at an entry's own level refutes it. True for
+    /// conditionals, which mirror a parse that stops at a `\par`; false for
+    /// aliases, whose body legitimately spans blank lines.
+    const PARAGRAPH_ANCHOR: bool;
+
+    /// The last index in the file that could ever settle an entry with a
+    /// closer — the C0 bound. `None` refuses the whole gate without scanning.
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize>;
+
+    /// Whether the control word at `i` opens a nested entry.
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool;
+
+    /// Whether the control word at `i` closes the innermost live entry.
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool;
+
+    /// Whether the closer at `closer` really pairs with the entry opened at
+    /// `opener`, for gates whose two halves carry a name to match. A `false`
+    /// settles that entry as unpaired and consumes the closer either way, so
+    /// an outer entry never inherits it.
+    fn pairs(&self, p: &Parser<'_>, opener: usize, closer: usize) -> bool {
+        let _ = (p, opener, closer);
+        true
+    }
+}
+
+/// [`Parser::conditional_closer`]'s policy: `\if…`-family openers pairing with
+/// the next `\fi` at their own level.
+struct ConditionalGate;
+
+impl GatePolicy for ConditionalGate {
+    const PARAGRAPH_ANCHOR: bool = true;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_fi
+    }
+
+    fn opens_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.conditional_openers.contains(&i)
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.conditional_flow_at(i) == Some(conditional::FlowWord::Fi)
+    }
 }
 
 struct Parser<'t> {
@@ -321,6 +394,9 @@ struct Parser<'t> {
     /// `GROUP`, no unclosed/unmatched diagnostic. Matched pairs still parse as
     /// groups. Computed per chunk by [`Self::macrocode_body`].
     plain_braces: std::collections::HashSet<usize>,
+    /// Bumped on every mutation of [`Self::plain_braces`], so a gate batch can
+    /// key on the set without cloning it ([`WalkKey`]).
+    plain_braces_version: u32,
     /// expl3 catcode-mode toggle tokens, ascending: `(token index, state after
     /// the toggle)`. The same fixed toggle set the lexer flips
     /// ([`expl_toggle`]), pre-scanned once so [`Self::in_expl_region`] is a
@@ -400,15 +476,16 @@ struct Parser<'t> {
     last_r_brace: Option<usize>,
     /// Last `\fi`-flavored flow word — bounds [`Self::conditional_closer`].
     last_fi: Option<usize>,
-    /// The most recent [`Self::conditional_closers_from`] batch, memoized with
-    /// the walk state its scan read. A lookup hits only when that key matches
-    /// the walk's current state *and* the queried opener was settled by the
-    /// batch; anything else re-batches from the queried opener. One slot is
-    /// all the reuse there is: [`Self::element`] queries each opener once, in
-    /// ascending order, under a stable state between re-batches. `RefCell`
-    /// because the gate is `&self` (the [`Self::alias_closer_memo`] pattern,
-    /// with a map where that memo keeps one verdict).
-    conditional_batch: std::cell::RefCell<Option<ConditionalBatch>>,
+    /// The most recent [`ConditionalGate`] batch ([`Self::gate_batch`]),
+    /// memoized with the walk state its scan read. A lookup hits only when
+    /// that key matches the walk's current state *and* the queried opener was
+    /// settled by the batch; anything else re-batches from the queried opener.
+    /// One slot is all the reuse there is: [`Self::element`] queries each
+    /// opener once, in ascending order, under a stable state between
+    /// re-batches. `RefCell` because the gate is `&self` (the
+    /// [`Self::alias_closer_memo`] pattern, with a map where that memo keeps
+    /// one verdict).
+    conditional_batch: std::cell::RefCell<Option<GateBatch>>,
     /// Tokens visited by the shape-gate scans, summed over the whole parse. A
     /// measurement hook for the linearity regression tests in this file's
     /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
@@ -554,6 +631,7 @@ impl<'t> Parser<'t> {
             group_opens: Vec::new(),
             macrocode_end: None,
             plain_braces: std::collections::HashSet::new(),
+            plain_braces_version: 0,
             expl_toggles,
             conditional_openers,
             last_alias_closer: alias_closers.keys().copied().max(),
@@ -2670,8 +2748,9 @@ impl<'t> Parser<'t> {
     ///
     /// **Cost.** Verdicts are computed in *batches* (`TODO.md`, container-stack
     /// C1): one forward scan seeded at the queried opener settles every
-    /// same-frame opener it passes ([`Self::conditional_closers_from`]), and
-    /// the batch is memoized against the walk state it read
+    /// same-frame opener it passes ([`Self::gate_batch`] under
+    /// [`ConditionalGate`]), and the batch is memoized against the walk state
+    /// it read
     /// ([`Self::conditional_batch`]) — so a run of top-level openers costs one
     /// O(n) pass where it used to cost one scan each. The scan stays bounded
     /// by the last `\fi`-flavored word in the file ([`Self::last_fi`], C0), so
@@ -2682,48 +2761,81 @@ impl<'t> Parser<'t> {
     /// `latexrelease.sty`, `memoir.cls`) were within noise of the pre-node
     /// parser even before the batch.
     fn conditional_closer(&self, open: usize) -> Option<usize> {
-        self.last_fi?;
-        let key = (self.macrocode_end, self.in_def_body, self.group_depth > 0);
-        if let Some(batch) = self.conditional_batch.borrow().as_ref()
+        self.gated_closer(open, &ConditionalGate, &self.conditional_batch)
+    }
+
+    /// The walk state a gate batch's scan reads — see [`WalkKey`].
+    fn walk_key(&self) -> WalkKey {
+        WalkKey {
+            macrocode_end: self.macrocode_end,
+            in_def_body: self.in_def_body,
+            in_group: self.group_depth > 0,
+            plain_braces: self.plain_braces_version,
+        }
+    }
+
+    /// The memoized front of [`Self::gate_batch`]: answer `open` from `memo`
+    /// when the batch there was harvested under the current walk state and
+    /// settled this opener, and otherwise re-batch from `open` and keep the
+    /// result.
+    ///
+    /// One slot per gate is all the reuse there is: the walk queries each
+    /// opener once, in ascending order, under a state that is stable between
+    /// re-batches.
+    fn gated_closer<P: GatePolicy>(
+        &self,
+        open: usize,
+        policy: &P,
+        memo: &std::cell::RefCell<Option<GateBatch>>,
+    ) -> Option<usize> {
+        // The C0 bound as an early-out: a file with no closer of this gate's
+        // shape refuses without scanning at all.
+        policy.last_closer(self)?;
+        let key = self.walk_key();
+        if let Some(batch) = memo.borrow().as_ref()
             && batch.key == key
             && let Some(&verdict) = batch.verdicts.get(&open)
         {
             return verdict;
         }
-        let verdicts = self.conditional_closers_from(open);
+        let verdicts = self.gate_batch(open, policy);
         let verdict = verdicts.get(&open).copied();
         debug_assert!(verdict.is_some(), "the batch must settle its own seed");
-        *self.conditional_batch.borrow_mut() = Some(ConditionalBatch { key, verdicts });
+        *memo.borrow_mut() = Some(GateBatch { key, verdicts });
         verdict.flatten()
     }
 
-    /// The batched walk behind [`Self::conditional_closer`]: one forward scan
-    /// seeded at `open` that also settles, as a by-product, every opener it
-    /// passes in the seed's own brace frame — the exact verdict each one's own
-    /// scan would have computed under the current walk state.
+    /// The batched walk behind every shape gate: one forward scan seeded at
+    /// `open` that also settles, as a by-product, every opener it passes in
+    /// the seed's own brace frame — the exact verdict each one's own scan
+    /// would have computed under the current walk state.
     ///
-    /// The transform from the per-opener scan is possible because that scan
+    /// The transform from a per-opener scan is possible because such a scan
     /// counts nested openers only at `depth == 0`: every opener this scan
     /// passes shares the seed's brace frame exactly, so `depth` is common to
     /// all of them, an entry's environment count relative to itself is
     /// `envs - envs_at_push`, and its nested-opener count is the number of
-    /// stack entries above it — `\fi` matching is pure LIFO.
+    /// stack entries above it — closer matching is pure LIFO.
     ///
     /// The one non-obvious rule: a refuted entry is **settled, never
-    /// removed**. The per-opener scan counts nested openers *by name*
-    /// (`conditional_openers` membership) and never un-counts one, so a later
-    /// `\fi` must still be consumed by the refuted entry's slot. In
+    /// removed**. A per-opener scan counts nested openers *by name*
+    /// ([`GatePolicy::opens_at`] membership) and never un-counts one, so a
+    /// later closer must still be consumed by the refuted entry's slot. In
     /// `\ifA \begin{center} \ifB \end{center} \fi \fi`, the unowed `\end`
     /// refutes `\ifB` — but `\ifA`'s own scan still counts `\ifB` as nested
     /// and pairs with the *second* `\fi`. Popping `\ifB` at the `\end` would
     /// hand the first `\fi` to `\ifA`: a different verdict, a different tree.
-    /// A `\fi` that pops an already-settled entry records nothing.
+    /// A closer that pops an already-settled entry records nothing. Every gate
+    /// that joins this driver has the same never-un-counted countdown, so the
+    /// rule is the driver's, not the conditional gate's.
     ///
-    /// Per anchor, mirroring the pre-batch scan token for token:
-    /// - a `\fi` at depth 0 pops the top entry; if it was still live, its
+    /// Per anchor, mirroring the pre-batch conditional scan token for token:
+    /// - a closer at depth 0 pops the top entry; if it was still live, its
     ///   verdict is `Some` iff no `\begin`-opened environment stands in the
-    ///   way (`envs == envs_at_push`, the old `envs == 0` restated);
-    /// - a paragraph break or an unowed `\end` refutes exactly the live
+    ///   way (`envs == envs_at_push`, the old `envs == 0` restated) and
+    ///   [`GatePolicy::pairs`] accepts it;
+    /// - a paragraph break (for a gate that anchors on one) or an unowed
+    ///   `\end` refutes exactly the live
     ///   entries at their own level (`envs_at_push == envs`) — a contiguous
     ///   top suffix of the live stack, whose `envs_at_push` values are
     ///   non-decreasing and capped at `envs` by construction — and the `\end`
@@ -2732,9 +2844,10 @@ impl<'t> Parser<'t> {
     ///   frame, and the end bound refute everything still live.
     ///
     /// The scan ends as soon as no live entry remains.
-    fn conditional_closers_from(
+    fn gate_batch<P: GatePolicy>(
         &self,
         open: usize,
+        policy: &P,
     ) -> std::collections::HashMap<usize, Option<usize>> {
         struct Entry {
             opener: usize,
@@ -2775,7 +2888,7 @@ impl<'t> Parser<'t> {
             .macrocode_end
             .unwrap_or(self.tokens.len())
             .min(self.tokens.len())
-            .min(self.last_fi.map_or(0, |last| last + 1));
+            .min(policy.last_closer(self).map_or(0, |last| last + 1));
         let mut i = open + 1;
         while i < end {
             self.tick_scan();
@@ -2786,7 +2899,7 @@ impl<'t> Parser<'t> {
                     // The old `paragraph_break_blocks(depth, envs)`, restated
                     // per entry: the break blocks at an entry's own level,
                     // `depth == 0 && envs == envs_at_push`.
-                    if newlines >= 2 && depth == 0 {
+                    if P::PARAGRAPH_ANCHOR && newlines >= 2 && depth == 0 {
                         settle_level(&mut pending, &mut live, &mut verdicts, envs);
                         if live.is_empty() {
                             return verdicts;
@@ -2801,7 +2914,7 @@ impl<'t> Parser<'t> {
                 }
                 // Math swallows whatever it spans, and this scan does not model
                 // the `$`/`\[`/`\(` shape gates that decide whether a delimiter
-                // opens any. Rather than re-derive them, refuse: a conditional
+                // opens any. Rather than re-derive them, refuse: a construct
                 // whose closer sits behind a math delimiter stays a plain command.
                 // A conservative false negative, per the parser's standing
                 // preference for them.
@@ -2815,8 +2928,8 @@ impl<'t> Parser<'t> {
                 SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
                     if depth == 0 {
                         // A `}` closing a group opened before the opener always
-                        // wins: braces are catcode structure while `\if`/`\fi`
-                        // are only macros. At the outer level there is no such
+                        // wins: braces are catcode structure while the gated
+                        // delimiters are only macros. At the outer level there is no such
                         // group, so a stray `}` is somebody else's business and
                         // the scan carries on (the `\begin` gate's `group_depth`
                         // guard, transcribed).
@@ -2828,26 +2941,27 @@ impl<'t> Parser<'t> {
                     }
                 }
                 SyntaxKind::CONTROL_WORD if depth == 0 => {
-                    if self.conditional_openers.contains(&i) {
+                    if policy.opens_at(self, i) {
                         live.push(pending.len());
                         pending.push(Entry {
                             opener: i,
                             envs_at_push: envs,
                             settled: false,
                         });
-                    } else if self.conditional_flow_at(i) == Some(conditional::FlowWord::Fi) {
+                    } else if policy.closes_at(self, i) {
                         let entry = pending
                             .pop()
                             .expect("a live entry remains, so pending is non-empty");
                         if !entry.settled {
                             live.pop();
                             // `envs == envs_at_push` for the same reason as
-                            // `depth == 0`: a `\fi` inside an environment the
-                            // conditional opened is consumed by that
+                            // `depth == 0`: a closer inside an environment the
+                            // construct opened is consumed by that
                             // environment's body, so it is not a closer the
                             // walk can reach.
-                            verdicts
-                                .insert(entry.opener, (envs == entry.envs_at_push).then_some(i));
+                            let paired =
+                                envs == entry.envs_at_push && policy.pairs(self, entry.opener, i);
+                            verdicts.insert(entry.opener, paired.then_some(i));
                             if live.is_empty() {
                                 return verdicts;
                             }
@@ -3275,12 +3389,14 @@ impl<'t> Parser<'t> {
             }
         }
         self.plain_braces.extend(open_stack);
+        self.plain_braces_version += 1;
         self.macrocode_end = Some(end);
         self.in_def_body = true;
 
         self.parse_block(Block::Macrocode);
 
         self.plain_braces = saved_plain;
+        self.plain_braces_version += 1;
         self.macrocode_end = saved_end;
         self.in_def_body = saved_def;
     }

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -261,6 +261,45 @@ struct GateBatch {
     verdicts: std::collections::HashMap<usize, Option<usize>>,
 }
 
+/// Where a batch deposits the verdicts it settles ([`Parser::gate_batch`]).
+///
+/// The driver has one loop and one set of `insert` calls; what varies is who
+/// keeps the results. A memoized gate keeps all of them, since the whole point
+/// is answering the openers ahead of the seed from one scan. A **single-entry**
+/// gate ([`Parser::gate_verdict`]) opens no nested entry, so the seed is the
+/// only opener its batch can ever settle — and building a `HashMap` to hold one
+/// verdict costs an allocation per `$` and `\[` in the document.
+///
+/// Discarding the non-seed verdicts is safe for *any* gate, not just a
+/// single-entry one: the driver's decisions never read back what it inserted.
+/// It is only worth doing where there is nothing else to keep.
+trait VerdictSink {
+    fn insert(&mut self, opener: usize, verdict: Option<usize>);
+}
+
+impl VerdictSink for std::collections::HashMap<usize, Option<usize>> {
+    fn insert(&mut self, opener: usize, verdict: Option<usize>) {
+        std::collections::HashMap::insert(self, opener, verdict);
+    }
+}
+
+/// The allocation-free [`VerdictSink`] for a single-entry gate: one slot for
+/// the seed, and everything else dropped on the floor.
+struct SeedVerdict {
+    seed: usize,
+    /// `None` until the batch settles the seed; the driver guarantees it does
+    /// (`debug_assert` in [`Parser::gate_verdict`]).
+    verdict: Option<Option<usize>>,
+}
+
+impl VerdictSink for SeedVerdict {
+    fn insert(&mut self, opener: usize, verdict: Option<usize>) {
+        if opener == self.seed {
+            self.verdict = Some(verdict);
+        }
+    }
+}
+
 /// What a `}` at a gate's own brace level means to that gate. The scan reached
 /// it without having opened the group, so the brace closes a group opened
 /// *before* the entries — or no group at all, when the walk itself is at the
@@ -1183,7 +1222,11 @@ struct Parser<'t> {
     /// Tokens visited by the shape-gate scans, summed over the whole parse. A
     /// measurement hook for the linearity regression tests in this file's
     /// `mod tests` — never a budget (`TODO.md` rejects scan budgets as
-    /// hard-coded special cases). `Cell` because the gates take `&self`.
+    /// hard-coded special cases). `Cell` because the gates take `&self`, and
+    /// `cfg(test)` because the counter is pure measurement: ticking it once per
+    /// scanned token is a real cost in the driver's hottest loop, paid for
+    /// nothing in a release build.
+    #[cfg(test)]
     scan_work: std::cell::Cell<usize>,
     /// The [`EnvGate`] twin of [`Self::conditional_batch`]. Its verdicts are
     /// the *scan's* alone: [`Self::environment_escapes_group`]'s per-opener
@@ -1356,6 +1399,7 @@ impl<'t> Parser<'t> {
             last_fi,
             last_dollar,
             conditional_batch: std::cell::RefCell::new(None),
+            #[cfg(test)]
             scan_work: std::cell::Cell::new(0),
             alias_openers,
             alias_closers,
@@ -2366,9 +2410,16 @@ impl<'t> Parser<'t> {
     }
 
     /// One tick per token a shape-gate scan visits, into [`Self::scan_work`].
+    /// Compiled away outside `cfg(test)`: the linearity regression tests are
+    /// the only reader, and [`Self::gate_batch`]'s loop is hot enough that an
+    /// unconditional counter shows up in the parse benchmarks.
+    #[cfg(test)]
     fn tick_scan(&self) {
         self.scan_work.set(self.scan_work.get() + 1);
     }
+
+    #[cfg(not(test))]
+    fn tick_scan(&self) {}
 
     /// True if the `[` at token index `open` is closed by a `]` before the
     /// current macrocode chunk's frame terminator. Depth-tracks only the braces
@@ -3156,9 +3207,13 @@ impl<'t> Parser<'t> {
     /// settled this opener, and otherwise re-batch from `open` and keep the
     /// result.
     ///
-    /// One slot per gate is all the reuse there is: the walk queries each
-    /// opener once, in ascending order, under a state that is stable between
-    /// re-batches.
+    /// One slot per gate is all the reuse there is *for verdicts*: the walk
+    /// queries each opener once, in ascending order, under a state that is
+    /// stable between re-batches. The slot's **storage** is reused further
+    /// than that — a miss takes the stale map, clears it, and refills it, so a
+    /// gate allocates about once per parse instead of once per re-batch. A
+    /// cleared `HashMap` keeps its capacity, and the batches of one gate over
+    /// one file are all much of a size.
     fn gated_closer<P: GatePolicy>(
         &self,
         open: usize,
@@ -3175,7 +3230,17 @@ impl<'t> Parser<'t> {
         {
             return verdict;
         }
-        let verdicts = self.gate_batch(open, policy);
+        // Recycle the superseded batch's map: its verdicts are stale (the key
+        // missed, or it did not settle this opener), but its allocation is not.
+        let mut verdicts =
+            memo.borrow_mut()
+                .take()
+                .map_or_else(std::collections::HashMap::new, |stale| {
+                    let mut map = stale.verdicts;
+                    map.clear();
+                    map
+                });
+        self.gate_batch(open, policy, &mut verdicts);
         let verdict = verdicts.get(&open).copied();
         debug_assert!(verdict.is_some(), "the batch must settle its own seed");
         *memo.borrow_mut() = Some(GateBatch { key, verdicts });
@@ -3191,19 +3256,29 @@ impl<'t> Parser<'t> {
     /// [`Self::element`] as a fresh opener: same token index, same walk state,
     /// but `display: false` — a *different question*, which a slot keyed on the
     /// walk state alone would answer from the display verdict.
+    ///
+    /// With nothing to memoize and nothing but the seed to settle, the batch
+    /// collects into a [`SeedVerdict`] rather than a map: these are the gates
+    /// the walk queries most (`$` and `\[` are everywhere), and a per-query
+    /// allocation for a single verdict is the whole cost of asking.
     fn gate_verdict<P: GatePolicy>(&self, open: usize, policy: &P) -> Option<usize> {
         // The C0 bound as an early-out, as in [`Self::gated_closer`].
         policy.last_closer(self)?;
-        let verdicts = self.gate_batch(open, policy);
-        let verdict = verdicts.get(&open).copied();
-        debug_assert!(verdict.is_some(), "the batch must settle its own seed");
-        verdict.flatten()
+        let mut sink = SeedVerdict {
+            seed: open,
+            verdict: None,
+        };
+        self.gate_batch(open, policy, &mut sink);
+        debug_assert!(sink.verdict.is_some(), "the batch must settle its own seed");
+        sink.verdict.flatten()
     }
 
     /// The batched walk behind every shape gate: one forward scan seeded at
     /// `open` that also settles, as a by-product, every opener it passes in
     /// the seed's own brace frame — the exact verdict each one's own scan
-    /// would have computed under the current walk state.
+    /// would have computed under the current walk state. Settled verdicts go
+    /// to `verdicts`, whose two implementations decide how many are kept
+    /// ([`VerdictSink`]); the scan itself never reads them back.
     ///
     /// The transform from a per-opener scan is possible because such a scan
     /// counts nested openers only at `depth == 0`: every opener this scan
@@ -3241,11 +3316,7 @@ impl<'t> Parser<'t> {
     ///   the end bound refute everything still live.
     ///
     /// The scan ends as soon as no live entry remains.
-    fn gate_batch<P: GatePolicy>(
-        &self,
-        open: usize,
-        policy: &P,
-    ) -> std::collections::HashMap<usize, Option<usize>> {
+    fn gate_batch<P: GatePolicy, S: VerdictSink>(&self, open: usize, policy: &P, verdicts: &mut S) {
         struct Entry {
             opener: usize,
             envs_at_push: usize,
@@ -3253,10 +3324,10 @@ impl<'t> Parser<'t> {
         }
         /// Settle every live entry sitting at its own environment level: the
         /// level anchor at hand refutes exactly those.
-        fn settle_level(
+        fn settle_level<S: VerdictSink>(
             pending: &mut [Entry],
             live: &mut Vec<usize>,
-            verdicts: &mut std::collections::HashMap<usize, Option<usize>>,
+            verdicts: &mut S,
             envs: usize,
         ) {
             while let Some(&idx) = live.last() {
@@ -3274,10 +3345,10 @@ impl<'t> Parser<'t> {
         /// stands inside it. The entries below are shielded by that frame and
         /// keep scanning — a settled entry keeps its frame, so a later closer
         /// still consumes it.
-        fn settle_innermost(
+        fn settle_innermost<S: VerdictSink>(
             pending: &mut [Entry],
             live: &mut Vec<usize>,
-            verdicts: &mut std::collections::HashMap<usize, Option<usize>>,
+            verdicts: &mut S,
             envs: usize,
         ) {
             let Some(entry) = pending.last_mut() else {
@@ -3294,7 +3365,6 @@ impl<'t> Parser<'t> {
             debug_assert_eq!(live.last().copied(), Some(pending.len() - 1));
             live.pop();
         }
-        let mut verdicts = std::collections::HashMap::new();
         let mut pending = vec![Entry {
             opener: open,
             envs_at_push: 0,
@@ -3348,14 +3418,14 @@ impl<'t> Parser<'t> {
                         // `stack.is_empty()` test cannot fire ([`Nesting`]).
                         match P::NESTING {
                             Nesting::Counted => {
-                                settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                                settle_level(&mut pending, &mut live, verdicts, envs);
                             }
                             Nesting::Interleaved => {
-                                settle_innermost(&mut pending, &mut live, &mut verdicts, envs);
+                                settle_innermost(&mut pending, &mut live, verdicts, envs);
                             }
                         }
                         if live.is_empty() {
-                            return verdicts;
+                            return;
                         }
                     }
                     i += 1;
@@ -3420,7 +3490,7 @@ impl<'t> Parser<'t> {
                                 for &idx in &live {
                                     verdicts.insert(pending[idx].opener, Some(i));
                                 }
-                                return verdicts;
+                                return;
                             }
                             StrayBrace::RefutesAlways => break,
                             _ => {}
@@ -3482,7 +3552,7 @@ impl<'t> Parser<'t> {
                             let paired = balanced && policy.pairs(self, entry.opener, i);
                             verdicts.insert(entry.opener, paired.then_some(i));
                             if live.is_empty() {
-                                return verdicts;
+                                return;
                             }
                         }
                     } else if t.kind == SyntaxKind::CONTROL_WORD
@@ -3541,9 +3611,9 @@ impl<'t> Parser<'t> {
                                     }
                                 }
                                 Nesting::Counted => {
-                                    settle_level(&mut pending, &mut live, &mut verdicts, envs);
+                                    settle_level(&mut pending, &mut live, verdicts, envs);
                                     if live.is_empty() {
-                                        return verdicts;
+                                        return;
                                     }
                                 }
                             }
@@ -3562,7 +3632,6 @@ impl<'t> Parser<'t> {
         for &idx in &live {
             verdicts.insert(pending[idx].opener, None);
         }
-        verdicts
     }
 
     /// The token index closing the environment-alias opener at `open`, or `None`

--- a/crates/badness-parser/src/parser/grammar.rs
+++ b/crates/badness-parser/src/parser/grammar.rs
@@ -253,19 +253,33 @@ struct GateBatch {
     verdicts: std::collections::HashMap<usize, Option<usize>>,
 }
 
-/// What a `}` closing a group opened *before* a gate's entries means to that
-/// gate. The token event is the same for every gate — braces are catcode
-/// structure while the gated delimiters are only macros, so the `}` always wins
-/// — but the *verdict* it implies is opposite either side of the positive
-/// gate/demotion gate line, which is why it is policy and not bookkeeping.
+/// What a `}` at a gate's own brace level means to that gate. The scan reached
+/// it without having opened the group, so the brace closes a group opened
+/// *before* the entries — or no group at all, when the walk itself is at the
+/// outer level.
+///
+/// The token event is the same for every gate — braces are catcode structure
+/// while the gated delimiters are only macros, so the `}` always wins — but the
+/// *verdict* it implies differs on two axes: the positive gate/demotion gate
+/// line, and whether a brace with no group behind it means anything. Both are
+/// policy, not bookkeeping.
 #[derive(PartialEq, Eq)]
 enum StrayBrace {
-    /// It refutes every live entry: a conditional or an alias cannot pair
-    /// across it, so the opener stays a plain command.
-    Refutes,
-    /// It *is* the closer: [`Parser::environment_escapes_group`] asks whether
-    /// the `\begin` escapes its group, and this brace is the escape.
-    Closes,
+    /// Refutes every live entry, but only when the walk sits inside a group
+    /// (`group_depth > 0`): a conditional or an alias cannot pair across the
+    /// `}` that ends the group its opener sits in, while at the outer level a
+    /// stray `}` is somebody else's business and the scan carries on.
+    RefutesInGroup,
+    /// It *is* the closer, on the same condition:
+    /// [`Parser::environment_escapes_group`] asks whether the `\begin` escapes
+    /// its group, and this brace is the escape.
+    ClosesInGroup,
+    /// Refutes every live entry unconditionally. The math gates mirror
+    /// [`Parser::dollar_math`] and [`Parser::delim_math`], which bail at *any*
+    /// unbalanced `}` — for them the brace is a recovery anchor of the parse
+    /// itself, not merely a group boundary — and a gate must mirror the parse
+    /// it guards.
+    RefutesAlways,
 }
 
 /// The per-gate half of [`Parser::gate_batch`]: how far this gate's scan can
@@ -281,18 +295,18 @@ enum StrayBrace {
 ///
 /// Hooks arrive with the client that needs them, so the driver stays
 /// *extracted* from C1's working batch rather than authored to a lowest common
-/// denominator. Today every client's delimiters are `CONTROL_WORD`s at the
-/// entries' own brace level, so that is all the driver classifies; the math
-/// and bracket gates widen it when they migrate.
+/// denominator. Delimiters are asked for at any token kind at the entries' own
+/// brace level, since the math gates close on a `DOLLAR` and a `CONTROL_SYMBOL`
+/// — every policy tests the kind inside its own predicate anyway.
 trait GatePolicy {
     /// Whether a blank line at an entry's own level refutes it. True for
     /// conditionals, which mirror a parse that stops at a `\par`; false for
     /// aliases, whose body legitimately spans blank lines.
     const PARAGRAPH_ANCHOR: bool;
 
-    /// What a `}` closing a group opened *before* the entries means. Defaults
-    /// to the *positive* gates' reading; see [`StrayBrace`].
-    const STRAY_BRACE: StrayBrace = StrayBrace::Refutes;
+    /// What a `}` at the entries' own brace level means. Defaults to the
+    /// *positive* gates' reading; see [`StrayBrace`].
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesInGroup;
 
     /// Whether a math delimiter at the entries' own level refutes them.
     ///
@@ -309,6 +323,40 @@ trait GatePolicy {
     /// then excludes its own environment — which its per-opener scan, starting
     /// one token past the `\begin`, never saw either.
     const OPENER_IS_ENV_BEGIN: bool = false;
+
+    /// Whether `\begin`/`\end` count toward `envs` at *any* brace depth, rather
+    /// than only at the entries' own.
+    ///
+    /// False for the gates whose entries pair at their own brace level: an
+    /// environment opened inside a `{…}` group is closed inside it too, so
+    /// counting it would say nothing about what stands between an entry and its
+    /// closer. The math gates set it true, as their pre-batch scans did: a math
+    /// body descends into a group ([`Parser::math_group`]) and keeps parsing
+    /// environments there, so `envs` tracks the whole body rather than one
+    /// brace level of it.
+    const ENVS_AT_ANY_DEPTH: bool = false;
+
+    /// Whether a closer only settles an entry when no `\begin`-opened
+    /// environment stands in the way (`envs == envs_at_push`).
+    ///
+    /// True for the gates whose closer is a *command*: one inside an environment
+    /// the construct opened is consumed by that environment's body, so the walk
+    /// never reaches it. The math gates set it false — their closer is a
+    /// delimiter, and `$\begin{matrix} … $` really does end at the `$`, the
+    /// environment's own recovery notwithstanding.
+    const CLOSER_NEEDS_ENV_BALANCE: bool = true;
+
+    /// Whether a `macrocode` chunk boundary refutes every live entry.
+    ///
+    /// True for the pairing gates: docstrip is line-oriented, so the code layer
+    /// and the documentation layer around it are different files as far as TeX
+    /// is concerned, and a construct that pairs across one runs over every chunk
+    /// between (`ltboxes.dtx`). The math gates set it false, preserving their
+    /// pre-batch scans, which counted `\begin{macrocode}` as an ordinary
+    /// environment. Nothing is known to depend on the difference; it is kept
+    /// because C2 migrates verdicts unchanged, not because it is the better
+    /// reading.
+    const MACROCODE_FRAME_ANCHORS: bool = true;
 
     /// The last index in the file that could ever settle an entry with a
     /// closer — the C0 bound. `None` refuses the whole gate without scanning.
@@ -397,7 +445,7 @@ impl GatePolicy for AliasGate {
 /// Three divergences from the positive gates, all following from that
 /// inversion:
 ///
-/// - **The stray `}` closes rather than refutes** ([`StrayBrace::Closes`]).
+/// - **The stray `}` closes rather than refutes** ([`StrayBrace::ClosesInGroup`]).
 ///   Same token event, opposite verdict.
 /// - **Math does not refuse** ([`GatePolicy::MATH_REFUTES`]). For a positive
 ///   gate, declining behind a math delimiter is the conservative direction; for
@@ -416,7 +464,7 @@ struct EnvGate;
 
 impl GatePolicy for EnvGate {
     const PARAGRAPH_ANCHOR: bool = false;
-    const STRAY_BRACE: StrayBrace = StrayBrace::Closes;
+    const STRAY_BRACE: StrayBrace = StrayBrace::ClosesInGroup;
     const MATH_REFUTES: bool = false;
     const OPENER_IS_ENV_BEGIN: bool = true;
 
@@ -430,6 +478,112 @@ impl GatePolicy for EnvGate {
 
     fn closes_at(&self, _p: &Parser<'_>, _i: usize) -> bool {
         false
+    }
+}
+
+/// [`Parser::delim_math_closes`]'s policy: `\[`/`\(` paired with its own
+/// `\]`/`\)` — and, with [`DollarGate`], one of the two **math** gates, which
+/// decide whether a delimiter opens math at all. What follows is what the two
+/// share; [`DollarGate`] adds its own wrinkle.
+///
+/// Both are **single-entry**: [`GatePolicy::opens_at`] is always false, so a
+/// batch settles its seed and nothing else. Their openers do not nest the way a
+/// conditional does — the parse they guard consumes the whole body, so an opener
+/// inside a math body is never re-gated, and an opener that is *not* inside one
+/// is answered by the first closer at its own level whatever came before it.
+/// With no LIFO to model there is no closer scope to hook, and the driver runs
+/// them for its bookkeeping alone.
+///
+/// Four divergences from the pairing gates, each stated as a policy rather than
+/// averaged into the loop:
+///
+/// - **A `}` refutes unconditionally** ([`StrayBrace::RefutesAlways`]): the
+///   guarded parses bail at any unbalanced `}`, group behind it or not.
+/// - **Math is not an anchor** ([`GatePolicy::MATH_REFUTES`]) — a foreign
+///   delimiter is ordinary content here, and for [`DollarGate`] the delimiter
+///   *is* the closer.
+/// - **Environments count at any depth** ([`GatePolicy::ENVS_AT_ANY_DEPTH`]).
+/// - **The closer needs no environment balance**
+///   ([`GatePolicy::CLOSER_NEEDS_ENV_BALANCE`]).
+///
+/// Both also read a `macrocode` frame as an ordinary environment
+/// ([`GatePolicy::MACROCODE_FRAME_ANCHORS`]), as their pre-batch scans did.
+///
+/// The paragraph anchor stays on, and the driver applies it at the entry's own
+/// level — `depth == 0 && envs == envs_at_push`, which for a lone seed is the
+/// old `depth == 0 && envs == 0` of the pre-batch scans exactly.
+struct DelimMathGate {
+    /// The closer this opener wants, `\]` or `\)`. The gate is per-flavor: a
+    /// `\)` never settles a `\[`, so each carries its own last-closer bound.
+    closer: &'static str,
+}
+
+impl GatePolicy for DelimMathGate {
+    const PARAGRAPH_ANCHOR: bool = true;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_REFUTES: bool = false;
+    const ENVS_AT_ANY_DEPTH: bool = true;
+    const CLOSER_NEEDS_ENV_BALANCE: bool = false;
+    const MACROCODE_FRAME_ANCHORS: bool = false;
+
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        if self.closer == "\\]" {
+            p.last_display_math_closer
+        } else {
+            p.last_inline_math_closer
+        }
+    }
+
+    fn opens_at(&self, _p: &Parser<'_>, _i: usize) -> bool {
+        false
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        let t = &p.tokens[i];
+        t.kind == SyntaxKind::CONTROL_SYMBOL && t.text.as_str() == self.closer
+    }
+}
+
+/// [`Parser::dollar_closes`]'s policy: `$`/`$$` paired with the next `$`/`$$` at
+/// its own level. The math gates' shared policy is documented on
+/// [`DelimMathGate`].
+///
+/// The one wrinkle beyond those: a display opener is two tokens, so the caller
+/// seeds the driver at the *second* `$` (the driver scans from `seed + 1`)
+/// rather than the driver growing a hook for it. That is also why the gate is
+/// unmemoized ([`Parser::gate_verdict`]) — a demoted `$$` re-enters
+/// [`Parser::element`] on its second `$`, which asks a *different* question
+/// (`display: false`) about the very index the display query seeded.
+struct DollarGate {
+    /// Whether the opener is `$$`, in which case only a `$` whose successor is
+    /// also a `$` closes it. A lone `$` inside display math is malformed but
+    /// consumed, exactly as [`Parser::dollar_math`] consumes it.
+    display: bool,
+}
+
+impl GatePolicy for DollarGate {
+    const PARAGRAPH_ANCHOR: bool = true;
+    const STRAY_BRACE: StrayBrace = StrayBrace::RefutesAlways;
+    const MATH_REFUTES: bool = false;
+    const ENVS_AT_ANY_DEPTH: bool = true;
+    const CLOSER_NEEDS_ENV_BALANCE: bool = false;
+    const MACROCODE_FRAME_ANCHORS: bool = false;
+
+    /// The last `$` in the file. Vacuous as a bound in the shape that motivated
+    /// it — a file of `$` openers ends at one — but the driver's contract is
+    /// that a gate names the last index that could ever settle an entry, and
+    /// this gate's closer is a `DOLLAR` like any other.
+    fn last_closer(&self, p: &Parser<'_>) -> Option<usize> {
+        p.last_dollar
+    }
+
+    fn opens_at(&self, _p: &Parser<'_>, _i: usize) -> bool {
+        false
+    }
+
+    fn closes_at(&self, p: &Parser<'_>, i: usize) -> bool {
+        p.tokens[i].kind == SyntaxKind::DOLLAR
+            && (!self.display || p.tokens.get(i + 1).map(|t| t.kind) == Some(SyntaxKind::DOLLAR))
     }
 }
 
@@ -594,6 +748,13 @@ struct Parser<'t> {
     last_r_brace: Option<usize>,
     /// Last `\fi`-flavored flow word — bounds [`Self::conditional_closer`].
     last_fi: Option<usize>,
+    /// Last `$` — bounds [`Self::dollar_closes`]. The weakest of these bounds by
+    /// construction, since this gate's closer is its opener's own token kind: in
+    /// the adversarial shape (a file of `$` openers) the last one *is* an
+    /// opener, so the bound cuts nothing. Recorded anyway, because the driver's
+    /// contract is that every gate names the last index that could settle an
+    /// entry, and a file whose `$`s all sit before a long tail does get the cut.
+    last_dollar: Option<usize>,
     /// The most recent [`ConditionalGate`] batch ([`Self::gate_batch`]),
     /// memoized with the walk state its scan read. A lookup hits only when
     /// that key matches the walk's current state *and* the queried opener was
@@ -652,6 +813,7 @@ impl<'t> Parser<'t> {
         let mut last_right = None;
         let mut last_r_brace = None;
         let mut last_fi = None;
+        let mut last_dollar = None;
         for (i, t) in tokens.iter().enumerate() {
             starts.push(off);
             off += t.text.len();
@@ -665,6 +827,7 @@ impl<'t> Parser<'t> {
             match t.kind {
                 SyntaxKind::R_BRACKET => last_r_bracket = Some(i),
                 SyntaxKind::R_BRACE => last_r_brace = Some(i),
+                SyntaxKind::DOLLAR => last_dollar = Some(i),
                 SyntaxKind::CONTROL_SYMBOL => match t.text.as_str() {
                     "\\]" => last_display_math_closer = Some(i),
                     "\\)" => last_inline_math_closer = Some(i),
@@ -763,6 +926,7 @@ impl<'t> Parser<'t> {
             last_right,
             last_r_brace,
             last_fi,
+            last_dollar,
             conditional_batch: std::cell::RefCell::new(None),
             scan_work: std::cell::Cell::new(0),
             alias_openers,
@@ -1989,22 +2153,6 @@ impl<'t> Parser<'t> {
         false
     }
 
-    /// Whether a paragraph break seen by the math shape gates
-    /// ([`Self::dollar_closes`], [`Self::delim_math_closes`]) ends the math.
-    ///
-    /// Only at the math body's own level. Both gates must mirror the parse
-    /// they guard, and `dollar_math`/`delim_math` test `at_paragraph_break`
-    /// only between top-level atoms: once the body descends into a `{…}`
-    /// group ([`Self::math_group`]) or a nested environment
-    /// ([`Self::environment`]), blank lines are ordinary body trivia and the
-    /// math runs on. Scanning them as blockers made the gate stricter than
-    /// the parse, so a display equation built out of `tikzpicture` cells
-    /// (`\[ \begin{array}… \begin{tikzpicture}<blank line>… \]`, issue #70)
-    /// lost its math node and reported its own `\]` as unmatched.
-    fn paragraph_break_blocks(depth: usize, envs: usize) -> bool {
-        depth == 0 && envs == 0
-    }
-
     /// True if the `$` (or `$$`) opener at token index `open` is closed by a
     /// matching delimiter before a token that would end the math. `$`/`$$` are
     /// data in macro code at least as often as they are math delimiters (a
@@ -2018,71 +2166,21 @@ impl<'t> Parser<'t> {
     /// dollar as an ordinary atom, never as the closer — and for `$$` a lone
     /// `$` is skipped exactly as `dollar_math` skips it (malformed but
     /// consumed). Likewise a paragraph break blocks only at the math body's
-    /// own level ([`Self::paragraph_break_blocks`]). Inside a definition body
-    /// `\begin`/`\end` are plain commands (issue #45), so neither anchors nor
-    /// nests there. Does not consume.
+    /// own level. Inside a definition body `\begin`/`\end` are plain commands
+    /// (issue #45), so neither anchors nor nests there. Does not consume.
+    ///
+    /// Runs on the shared batch driver as [`DollarGate`] (`TODO.md`, container
+    /// stack C2.3) — for the uniformity, not for speed: the gate is
+    /// single-entry, so its "batch" is one verdict, and its residual adversarial
+    /// shape (a `${` per line: depth ratchets upward, so the level-gated
+    /// paragraph anchor never fires and no depth-0 `$` ever appears) is one only
+    /// a precomputed map could reach.
+    ///
+    /// A display opener is two tokens and its scan starts past both, so the seed
+    /// handed to the driver — which scans from `seed + 1` — is the *second* `$`.
     fn dollar_closes(&self, open: usize, display: bool) -> bool {
-        // The one gate with no last-closer bound: its closer (`DOLLAR`) is its
-        // opener's own token kind, so the last one in a file of openers is just
-        // the final opener — the bound would be vacuous. The residual
-        // adversarial shape (a `${` per line: depth ratchets upward, so the
-        // level-gated paragraph anchor never fires and no depth-0 `$` ever
-        // appears) is recorded in `TODO.md` (container stack, C2).
-        let mut depth = 0usize;
-        let mut envs = 0usize;
-        let mut newlines = 0;
-        let start = open + if display { 2 } else { 1 };
-        let end = self
-            .macrocode_end
-            .unwrap_or(self.tokens.len())
-            .min(self.tokens.len());
-        let mut i = start;
-        while i < end {
-            self.tick_scan();
-            let t = &self.tokens[i];
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newlines += 1;
-                    if newlines >= 2 && Self::paragraph_break_blocks(depth, envs) {
-                        return false;
-                    }
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => {
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
-                    if depth == 0 {
-                        return false;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::DOLLAR if depth == 0 => {
-                    if !display
-                        || self.tokens.get(i + 1).map(|t| t.kind) == Some(SyntaxKind::DOLLAR)
-                    {
-                        return true;
-                    }
-                }
-                SyntaxKind::CONTROL_WORD if !self.in_macro_code(i) => {
-                    if t.text.as_str() == BEGIN_CMD && self.env_name_follows(i) {
-                        envs += 1;
-                    } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                        if envs == 0 {
-                            return false;
-                        }
-                        envs -= 1;
-                    }
-                }
-                _ => {}
-            }
-            newlines = 0;
-            i += 1;
-        }
-        false
+        let seed = if display { open + 1 } else { open };
+        self.gate_verdict(seed, &DollarGate { display }).is_some()
     }
 
     /// The delimited-math twin of [`Self::dollar_closes`]: `\[`/`\(` opens
@@ -2096,73 +2194,17 @@ impl<'t> Parser<'t> {
     /// [`Self::delim_math`]'s recovery anchors: an unbalanced `}`, an `\end`
     /// not owed to an intervening `\begin`, a paragraph break, the macrocode
     /// chunk end, EOF. The closer counts only outside `{…}` nesting, and a
-    /// paragraph break blocks only at the math body's own level
-    /// ([`Self::paragraph_break_blocks`]).
-    fn delim_math_closes(&self, open: usize, closer: &str) -> bool {
-        // Bounded by the last occurrence of *this* closer in the file (the
-        // `last_alias_closer` treatment): every `true` is at one, so past it
-        // only refusals remain, and a file with none refuses without scanning.
-        // Without the bound, a non-`.dtx` file of `\[` openers with no closer
-        // and no blank line scanned each one to EOF — quadratic (`TODO.md`,
-        // container stack C0).
-        let last = match closer {
-            "\\]" => self.last_display_math_closer,
-            _ => self.last_inline_math_closer,
-        };
-        let Some(last) = last else {
-            return false;
-        };
-        let mut depth = 0usize;
-        let mut envs = 0usize;
-        let mut newlines = 0;
-        let end = self
-            .macrocode_end
-            .unwrap_or(self.tokens.len())
-            .min(self.tokens.len())
-            .min(last + 1);
-        let mut i = open + 1;
-        while i < end {
-            self.tick_scan();
-            let t = &self.tokens[i];
-            match t.kind {
-                SyntaxKind::NEWLINE => {
-                    newlines += 1;
-                    if newlines >= 2 && Self::paragraph_break_blocks(depth, envs) {
-                        return false;
-                    }
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::WHITESPACE | SyntaxKind::DOC_MARGIN | SyntaxKind::GUARD => {
-                    i += 1;
-                    continue;
-                }
-                SyntaxKind::L_BRACE if !self.plain_braces.contains(&i) => depth += 1,
-                SyntaxKind::R_BRACE if !self.plain_braces.contains(&i) => {
-                    if depth == 0 {
-                        return false;
-                    }
-                    depth -= 1;
-                }
-                SyntaxKind::CONTROL_SYMBOL if depth == 0 && t.text.as_str() == closer => {
-                    return true;
-                }
-                SyntaxKind::CONTROL_WORD if !self.in_macro_code(i) => {
-                    if t.text.as_str() == BEGIN_CMD && self.env_name_follows(i) {
-                        envs += 1;
-                    } else if t.text.as_str() == END_CMD && self.env_name_follows(i) {
-                        if envs == 0 {
-                            return false;
-                        }
-                        envs -= 1;
-                    }
-                }
-                _ => {}
-            }
-            newlines = 0;
-            i += 1;
-        }
-        false
+    /// paragraph break blocks only at the math body's own level.
+    ///
+    /// Runs on the shared batch driver as [`DelimMathGate`] (`TODO.md`,
+    /// container stack C2.3), which carries the C0 bound — the last `\]`/`\)` in
+    /// the file — as [`GatePolicy::last_closer`]. The gate is single-entry: a
+    /// `\[` whose closer is reachable swallows every opener up to it, so there
+    /// is never a same-frame neighbor left to settle, and it was measured linear
+    /// before the migration. It joins the driver for the one copy of the
+    /// bookkeeping, not for speed.
+    fn delim_math_closes(&self, open: usize, closer: &'static str) -> bool {
+        self.gate_verdict(open, &DelimMathGate { closer }).is_some()
     }
 
     /// The `\left…\right` twin of [`Self::delim_math_closes`]: whether the
@@ -2809,9 +2851,9 @@ impl<'t> Parser<'t> {
     ///   the `\iffalse}\fi` editor-balance hack demote instead of swallowing the
     ///   chunk.
     ///
-    /// A paragraph break anchors at the construct's own level only
-    /// ([`Self::paragraph_break_blocks`]), so the ~11% of corpus conditionals
-    /// that span a blank line demote and keep their pre-node layout. That keeps
+    /// A paragraph break anchors at the construct's own level only, so the ~11%
+    /// of corpus conditionals that span a blank line demote and keep their
+    /// pre-node layout. That keeps
     /// `CONDITIONAL` a within-paragraph construct: it can never straddle a
     /// `PARAGRAPH` boundary, so no paragraph nests inside one.
     ///
@@ -2897,6 +2939,24 @@ impl<'t> Parser<'t> {
         verdict.flatten()
     }
 
+    /// The unmemoized front, for a **single-entry** gate ([`DelimMathGate`],
+    /// [`DollarGate`]): one that opens no nested entry, so its batch settles the
+    /// seed and nothing else and there is no neighbor to save.
+    ///
+    /// A memo slot would not merely be idle here, it would be a hazard. The one
+    /// re-query these gates see is a demoted `$$` whose second `$` re-enters
+    /// [`Self::element`] as a fresh opener: same token index, same walk state,
+    /// but `display: false` — a *different question*, which a slot keyed on the
+    /// walk state alone would answer from the display verdict.
+    fn gate_verdict<P: GatePolicy>(&self, open: usize, policy: &P) -> Option<usize> {
+        // The C0 bound as an early-out, as in [`Self::gated_closer`].
+        policy.last_closer(self)?;
+        let verdicts = self.gate_batch(open, policy);
+        let verdict = verdicts.get(&open).copied();
+        debug_assert!(verdict.is_some(), "the batch must settle its own seed");
+        verdict.flatten()
+    }
+
     /// The batched walk behind every shape gate: one forward scan seeded at
     /// `open` that also settles, as a by-product, every opener it passes in
     /// the seed's own brace frame — the exact verdict each one's own scan
@@ -2924,16 +2984,18 @@ impl<'t> Parser<'t> {
     /// Per anchor, mirroring the pre-batch conditional scan token for token:
     /// - a closer at depth 0 pops the top entry; if it was still live, its
     ///   verdict is `Some` iff no `\begin`-opened environment stands in the
-    ///   way (`envs == envs_at_push`, the old `envs == 0` restated) and
-    ///   [`GatePolicy::pairs`] accepts it;
+    ///   way (`envs == envs_at_push`, the old `envs == 0` restated — waived by
+    ///   [`GatePolicy::CLOSER_NEEDS_ENV_BALANCE`]) and [`GatePolicy::pairs`]
+    ///   accepts it;
     /// - a paragraph break (for a gate that anchors on one) or an unowed
     ///   `\end` refutes exactly the live
     ///   entries at their own level (`envs_at_push == envs`) — a contiguous
     ///   top suffix of the live stack, whose `envs_at_push` values are
     ///   non-decreasing and capped at `envs` by construction — and the `\end`
     ///   then decrements `envs` for the survivors;
-    /// - math, an unbalanced `}` under an enclosing group, a `macrocode`
-    ///   frame, and the end bound refute everything still live.
+    /// - math, an unbalanced `}` (under an enclosing group, or anywhere for a
+    ///   gate reading [`StrayBrace::RefutesAlways`]), a `macrocode` frame, and
+    ///   the end bound refute everything still live.
     ///
     /// The scan ends as soon as no live entry remains.
     fn gate_batch<P: GatePolicy>(
@@ -2988,9 +3050,13 @@ impl<'t> Parser<'t> {
             match t.kind {
                 SyntaxKind::NEWLINE => {
                     newlines += 1;
-                    // The old `paragraph_break_blocks(depth, envs)`, restated
-                    // per entry: the break blocks at an entry's own level,
-                    // `depth == 0 && envs == envs_at_push`.
+                    // A break anchors at an entry's *own* level only,
+                    // `depth == 0 && envs == envs_at_push`. Deeper than that it
+                    // is ordinary body trivia, and a gate stricter than the
+                    // parse it guards drops the node: a display equation built
+                    // out of `tikzpicture` cells (`\[ \begin{array}…
+                    // \begin{tikzpicture}<blank line>… \]`, issue #70) lost its
+                    // math node and reported its own `\]` as unmatched.
                     if P::PARAGRAPH_ANCHOR && newlines >= 2 && depth == 0 {
                         settle_level(&mut pending, &mut live, &mut verdicts, envs);
                         if live.is_empty() {
@@ -3024,31 +3090,36 @@ impl<'t> Parser<'t> {
                     if depth == 0 {
                         // A `}` closing a group opened before the opener always
                         // wins: braces are catcode structure while the gated
-                        // delimiters are only macros. At the outer level there
-                        // is no such group, so a stray `}` is somebody else's
-                        // business and the scan carries on. What the brace
-                        // *means* is the gate's own call ([`StrayBrace`]).
-                        if self.group_depth > 0 {
-                            match P::STRAY_BRACE {
-                                StrayBrace::Refutes => break,
-                                StrayBrace::Closes => {
-                                    // Every live entry escapes at the same
-                                    // brace: `depth` is common to the whole
-                                    // frame, so each one's own scan would reach
-                                    // this `}` at its own depth 0 too.
-                                    for &idx in &live {
-                                        verdicts.insert(pending[idx].opener, Some(i));
-                                    }
-                                    return verdicts;
+                        // delimiters are only macros. Whether one with *no* such
+                        // group behind it (`group_depth == 0`) means anything,
+                        // and what it means at all, is the gate's own call
+                        // ([`StrayBrace`]).
+                        match P::STRAY_BRACE {
+                            StrayBrace::RefutesInGroup if self.group_depth > 0 => break,
+                            StrayBrace::ClosesInGroup if self.group_depth > 0 => {
+                                // Every live entry escapes at the same brace:
+                                // `depth` is common to the whole frame, so each
+                                // one's own scan would reach this `}` at its own
+                                // depth 0 too.
+                                for &idx in &live {
+                                    verdicts.insert(pending[idx].opener, Some(i));
                                 }
+                                return verdicts;
                             }
+                            StrayBrace::RefutesAlways => break,
+                            _ => {}
                         }
                     } else {
                         depth -= 1;
                     }
                 }
-                SyntaxKind::CONTROL_WORD if depth == 0 => {
-                    if policy.opens_at(self, i) {
+                // Any token at the entries' own brace level may be a delimiter:
+                // the pairing gates close on a `CONTROL_WORD`, but the math
+                // gates close on a `DOLLAR` and a `CONTROL_SYMBOL`. Every policy
+                // tests the kind inside its own predicate, so asking wider costs
+                // the narrow ones nothing but the call.
+                _ => {
+                    if depth == 0 && policy.opens_at(self, i) {
                         // A gate whose openers are `\begin`s counts this one
                         // before pushing, so the entry's own environment is not
                         // in its `envs_at_push` — its per-opener scan starts one
@@ -3062,7 +3133,7 @@ impl<'t> Parser<'t> {
                             envs_at_push: envs,
                             settled: false,
                         });
-                    } else if policy.closes_at(self, i) {
+                    } else if depth == 0 && policy.closes_at(self, i) {
                         let entry = pending
                             .pop()
                             .expect("a live entry remains, so pending is non-empty");
@@ -3072,15 +3143,21 @@ impl<'t> Parser<'t> {
                             // `depth == 0`: a closer inside an environment the
                             // construct opened is consumed by that
                             // environment's body, so it is not a closer the
-                            // walk can reach.
-                            let paired =
-                                envs == entry.envs_at_push && policy.pairs(self, entry.opener, i);
+                            // walk can reach — unless the closer is a *math
+                            // delimiter*, which ends the body wherever it sits
+                            // ([`GatePolicy::CLOSER_NEEDS_ENV_BALANCE`]).
+                            let balanced =
+                                !P::CLOSER_NEEDS_ENV_BALANCE || envs == entry.envs_at_push;
+                            let paired = balanced && policy.pairs(self, entry.opener, i);
                             verdicts.insert(entry.opener, paired.then_some(i));
                             if live.is_empty() {
                                 return verdicts;
                             }
                         }
-                    } else if !self.in_macro_code(i) {
+                    } else if t.kind == SyntaxKind::CONTROL_WORD
+                        && (depth == 0 || P::ENVS_AT_ANY_DEPTH)
+                        && !self.in_macro_code(i)
+                    {
                         // In a definition body or an expl3 region `\begin`/`\end`
                         // are plain commands that need not pair, so neither
                         // anchors nor nests there (issues #45/#60).
@@ -3096,9 +3173,12 @@ impl<'t> Parser<'t> {
                             // the cursor past `macrocode_end` for every
                             // chunk-bounded scan downstream. (The other direction
                             // is already bounded: a conditional *inside* a chunk
-                            // scans only to `macrocode_end`.)
-                            if peek_begin_name(self.tokens, i)
-                                .is_some_and(|n| matches!(n.as_str(), "macrocode" | "macrocode*"))
+                            // scans only to `macrocode_end`.) The math gates opt
+                            // out ([`GatePolicy::MACROCODE_FRAME_ANCHORS`]).
+                            if P::MACROCODE_FRAME_ANCHORS
+                                && peek_begin_name(self.tokens, i).is_some_and(|n| {
+                                    matches!(n.as_str(), "macrocode" | "macrocode*")
+                                })
                             {
                                 break;
                             }
@@ -3114,13 +3194,12 @@ impl<'t> Parser<'t> {
                         }
                     }
                 }
-                _ => {}
             }
             newlines = 0;
             i += 1;
         }
-        // Global refusals — math, an unbalanced `}` under an enclosing group,
-        // a `macrocode` frame, the end bound: everything still live demotes.
+        // Global refusals — math, an unbalanced `}`, a `macrocode` frame, the
+        // end bound: everything still live demotes.
         for &idx in &live {
             verdicts.insert(pending[idx].opener, None);
         }
@@ -3760,6 +3839,33 @@ mod tests {
         // anywhere — the pair stack stays non-empty, so the blank-line anchor
         // alone never cuts the scan.
         let body = |n: usize| format!("\\[\n{}\\]\n", "\\left( x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+    }
+
+    /// The math gates' one-closer-at-EOF shapes (`TODO.md`, container stack
+    /// C2.3). These stay linear for a reason the batch does not supply: the
+    /// gates are single-entry, and the first opener whose closer is reachable
+    /// *swallows* every opener after it, so there is no second query to make.
+    /// The pin is on the shape, not on the mechanism — a future gate that
+    /// re-gated openers inside a math body would fail here.
+    ///
+    /// The one shape that stays quadratic is deliberate and recorded: a `${`
+    /// per line ratchets the brace depth upward and never returns to 0, so no
+    /// later opener sits at the seed's level and every one re-scans. Only a
+    /// precomputed per-frame map could reach it; a batch cannot, and this test
+    /// does not pretend otherwise.
+    #[test]
+    fn math_batch_stays_linear_with_one_closer_at_eof() {
+        // `delim_math_closes`, both flavors.
+        let body = |n: usize| format!("{}\\]\n", "\\[ x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+        let body = |n: usize| format!("{}\\)\n", "\\( x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+        // `dollar_closes`: a run of `$` openers, each paired by the next.
+        let body = |n: usize| format!("{}$\n", "$ x\n".repeat(n));
+        assert_scan_work_linear(&body(200), &body(400));
+        // The display twin, whose seed sits one token past the opener.
+        let body = |n: usize| format!("{}$$\n", "$$ x\n".repeat(n));
         assert_scan_work_linear(&body(200), &body(400));
     }
 }

--- a/crates/badness-parser/tests/parser.rs
+++ b/crates/badness-parser/tests/parser.rs
@@ -1388,6 +1388,17 @@ fn dollar_display_without_closer_gates_each_dollar() {
 }
 
 #[test]
+fn demoted_display_dollar_regates_its_second_dollar_as_inline() {
+    // `$$ a $`: no `$$` closer, so the display opener is demoted and its
+    // *second* `$` re-enters the gate — where it does pair, as inline math.
+    // The two queries land on the same token index under the same walk state
+    // but ask different questions (`display: true` then `false`), which is why
+    // the `$` gate runs unmemoized (container stack C2.3): a batch slot keyed
+    // on the walk state alone would answer the second from the first.
+    insta::assert_snapshot!(tree("$$ a $"));
+}
+
+#[test]
 fn dollar_math_still_pairs_across_groups_and_environments() {
     // The gate must not regress legit math: a closer past balanced `{…}`
     // nesting and a balanced `\begin…\end` still opens math.

--- a/crates/badness-parser/tests/parser.rs
+++ b/crates/badness-parser/tests/parser.rs
@@ -1184,7 +1184,7 @@ fn a_refuted_nested_opener_still_consumes_a_fi() {
     // unowed `\end{center}` demotes `\ifdim`, but `\ifdim`'s slot still
     // consumes the lone `\fi`, so the outer `\ifnum` runs out of closers and
     // demotes too. The batched scan must settle a refuted entry *without*
-    // removing it from the pending stack (`conditional_closers_from`);
+    // removing it from the pending stack (`Parser::gate_batch`);
     // popping it would hand the `\fi` to `\ifnum` — a `CONDITIONAL` the
     // per-opener scan never built. (The two-`\fi` sibling of this shape is
     // `conditional_walk_may_close_before_the_located_fi`.)

--- a/crates/badness-parser/tests/parser.rs
+++ b/crates/badness-parser/tests/parser.rs
@@ -1102,6 +1102,56 @@ fn a_blank_line_inside_a_nested_group_does_not_anchor() {
 }
 
 #[test]
+fn a_refuted_nested_opener_still_consumes_a_fi() {
+    // The gate counts nested openers by name and never un-counts one: the
+    // unowed `\end{center}` demotes `\ifdim`, but `\ifdim`'s slot still
+    // consumes the lone `\fi`, so the outer `\ifnum` runs out of closers and
+    // demotes too. The batched scan must settle a refuted entry *without*
+    // removing it from the pending stack (`conditional_closers_from`);
+    // popping it would hand the `\fi` to `\ifnum` — a `CONDITIONAL` the
+    // per-opener scan never built. (The two-`\fi` sibling of this shape is
+    // `conditional_walk_may_close_before_the_located_fi`.)
+    assert_eq!(
+        conditionals(r"\ifnum1<2 \begin{center}\ifdim1pt<2pt \end{center}x\fi"),
+        []
+    );
+}
+
+#[test]
+fn a_blank_line_inside_a_nested_environment_demotes_only_the_inner_opener() {
+    // The paragraph break sits at the inner conditional's own level (inside
+    // `center`), so it refutes `\ifcmh` alone; the outer `\ifnum`, one
+    // environment up, pairs across it — the batched scan settles exactly the
+    // level-matching suffix of its live entries.
+    assert_eq!(
+        conditionals("\\ifnum1<2 \\begin{center}\\ifcmh a\n\nb\\fi\\end{center}\\fi\n"),
+        [(1, true)]
+    );
+}
+
+#[test]
+fn a_fi_inside_an_environment_the_conditional_opened_is_not_its_closer() {
+    // The `\fi` is consumed by the environment's body, so the walk cannot
+    // reach it: the closer must sit at the opener's own environment level.
+    assert_eq!(
+        conditionals(r"\ifnum1<2 \begin{center}x\fi\end{center}"),
+        []
+    );
+}
+
+#[test]
+fn a_macrocode_frame_refutes_every_pending_opener() {
+    // The chunk boundary is hard in both directions; the outer opener and the
+    // nested one it counted demote together, in one batch.
+    assert_eq!(
+        conditionals(
+            "\\ifnum1<2 \\ifdim1pt<2pt a\\begin{macrocode}\nb\\fi\\fi\n\\end{macrocode}\n"
+        ),
+        []
+    );
+}
+
+#[test]
 fn newif_declares_a_flag_without_opening_a_conditional() {
     // 574 corpus occurrences. The `\if@foo` after `\newif` is the flag being
     // declared, not an opener; the *use* below it is the real conditional.

--- a/crates/badness-parser/tests/parser.rs
+++ b/crates/badness-parser/tests/parser.rs
@@ -1370,6 +1370,100 @@ fn math_bracket_with_own_closer_still_attaches_past_interval() {
     );
 }
 
+// --- the batched bracket family (container stack C2.5) -----------------------
+
+/// Whether each `[` in `src`, in source order, attaches as an `OPTIONAL`.
+fn bracket_attachments(src: &str) -> Vec<bool> {
+    let parsed = parse(src);
+    assert_eq!(parsed.syntax().to_string(), src, "losslessness");
+    parsed
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(|e| e.into_token())
+        .filter(|t| t.kind() == SyntaxKind::L_BRACKET)
+        .map(|t| t.parent().is_some_and(|p| p.kind() == SyntaxKind::OPTIONAL))
+        .collect()
+}
+
+#[test]
+fn nested_bracket_claims_settle_innermost_first() {
+    // The claim countdown of issue #55, seen from the batch that now computes
+    // it: one scan settles every command-abutting `[` in the frame, and closer
+    // matching is LIFO, so the lone `]` belongs to the innermost opener and the
+    // two around it stay ordinary tokens. The pre-batch code asked each opener
+    // in turn and had to arrive at the same three verdicts.
+    assert_eq!(
+        bracket_attachments("\\a[x\n\\b[y\n\\c[z\n]\n"),
+        [false, false, true]
+    );
+}
+
+#[test]
+fn a_bracket_refuses_an_anchor_inside_a_group() {
+    // Both the environment anchor and the paragraph break are depth-*blind* for
+    // this family (`ParagraphAnchor::AnyDepth`, `ANCHORS_AT_ANY_DEPTH`), because
+    // the `optional` walk they guard is: it bails wherever the cursor stands, so
+    // a gate that read either only at the bracket's own brace level would attach
+    // an optional the walk then reports unclosed.
+    assert_eq!(
+        bracket_attachments("\\cmd[{\\begin{center}a\\end{center}} x]"),
+        [false]
+    );
+    assert_eq!(bracket_attachments("\\cmd[{ x\n\ny} ]\n"), [false]);
+}
+
+#[test]
+fn a_math_bracket_anchors_on_an_environment_inside_macro_code() {
+    // In a definition body `\begin`/`\end` are plain commands (issues #45/#60),
+    // so the text-mode gate ignores them and the bracket attaches.
+    assert_eq!(
+        bracket_attachments(r"\newcommand{\x}{\cmd[a \begin{center} b]}"),
+        [true]
+    );
+    // The same body inside math refuses: the in-math gate's environment anchor
+    // carries no `in_macro_code` filter (`ENV_ANCHOR_IN_MACRO_CODE`), so it is
+    // stricter there than the `optional` bail it mirrors. Preserved from the
+    // pre-batch scan, in the direction that only ever declines to attach.
+    assert_eq!(
+        bracket_attachments(r"\newcommand{\x}{$\cmd[a \begin{center} b]$}"),
+        [false]
+    );
+}
+
+#[test]
+fn a_guard_line_does_not_part_a_macrocode_optional() {
+    // `rotating.dtx`: `\ProvidesPackage`'s date optional runs over several
+    // docstrip guard lines inside one `macrocode` chunk. Docstrip *deletes* a
+    // guard-only line when it strips the file, so it does not part what
+    // surrounds it (issue #71) — and this gate is the one that reads it that
+    // way, skipping only whitespace in its paragraph run
+    // (`DOC_TRIVIA_FLOATS`). Floating the guard like every other gate does
+    // would make the two newlines around it a blank line and drop the argument.
+    let src = concat!(
+        "%    \\begin{macrocode}\n",
+        "\\ProvidesPackage{rot}%\n",
+        "    [2026 v1\n",
+        "%<*dtx>\n",
+        "  more%\n",
+        "%</dtx>\n",
+        "        ]\n",
+        "%    \\end{macrocode}\n",
+    );
+    assert_eq!(bracket_attachments(src), [true]);
+    // A real blank line in the same place still refuses, so the run is read,
+    // not ignored.
+    let src = concat!(
+        "%    \\begin{macrocode}\n",
+        "\\ProvidesPackage{rot}%\n",
+        "    [2026 v1\n",
+        "\n",
+        "  more%\n",
+        "        ]\n",
+        "%    \\end{macrocode}\n",
+    );
+    assert_eq!(bracket_attachments(src), [false]);
+}
+
 // --- block-vs-inline paragraph wrapping --------------------------------------
 
 /// The kinds of the root's direct child *nodes* (trivia tokens are skipped, as

--- a/crates/badness-parser/tests/parser.rs
+++ b/crates/badness-parser/tests/parser.rs
@@ -215,6 +215,83 @@ fn left_right_pairs_inside_macro_code() {
 }
 
 #[test]
+fn left_right_pairs_across_a_math_opener() {
+    // The gate's math anchor is the *closing* side (`MathAnchor::Closing`): a
+    // `\left` already sits inside a math body, so what ends it is the delimiter
+    // that ends that body. A `\[` in the way is ordinary content — it opens no
+    // math here (`delim_math_closes` refuses it: no `\]` in reach) — so the pair
+    // still closes at its `\right`.
+    let src = r"$\left( \[ x \right)$";
+    let parsed = parse(src);
+    assert_eq!(parsed.syntax().to_string(), src);
+    assert!(
+        tree(src).contains("LEFT_RIGHT"),
+        "a math *opener* in the way must not refuse the pair"
+    );
+}
+
+#[test]
+fn left_right_refuses_across_a_math_closer() {
+    // The mirror: `\]` ends the display the `\left` lives in, so the `\right`
+    // beyond it is unreachable and the `\left` stays an ordinary command — the
+    // same anchor `left_right`'s own walk stops at, with no diagnostic.
+    let src = "\\[ \\left( x \\]\n";
+    let parsed = parse(src);
+    assert_eq!(parsed.syntax().to_string(), src);
+    assert!(
+        !tree(src).contains("LEFT_RIGHT"),
+        "a `\\left` whose `\\right` sits past the math's end must not pair"
+    );
+    assert!(
+        parsed.errors.is_empty(),
+        "a gated `\\left` draws no diagnostic: {:?}",
+        parsed
+            .errors
+            .iter()
+            .map(|e| e.message.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn an_end_inside_a_nested_left_refuses_the_whole_scan() {
+    // `\left`/`\right` frames and environment frames share one stack
+    // (`Nesting::Interleaved`), so an `\end` that finds a `\left` frame innermost
+    // is a mismatch — and the same mismatch every *outer* `\left` sees, since
+    // that frame is innermost for them too. Both openers demote; neither may pair
+    // with the `\right]`/`\right)` beyond the `\end`.
+    let src = r"$\left( \begin{matrix} a \left[ \end{matrix} \right] \right)$";
+    let parsed = parse(src);
+    assert_eq!(parsed.syntax().to_string(), src);
+    assert!(
+        !tree(src).contains("LEFT_RIGHT"),
+        "an `\\end` reached inside a nested `\\left` must refuse every open pair"
+    );
+}
+
+#[test]
+fn a_nested_left_shields_the_outer_pair_from_a_paragraph_break() {
+    // The other half of the interleaved model, and its one asymmetry: a *mismatch*
+    // is shared, but an *absence* of frames is not. The blank-line anchor asks
+    // whether the frame stack is empty, which is true only for the innermost
+    // `\left`, so the inner one demotes and the outer keeps scanning to its
+    // `\right)`.
+    //
+    // The gate is looser than the walk here — `left_right` bails at the paragraph
+    // break itself and reports the outer `\left` unclosed. Pre-existing, and
+    // preserved verbatim by the batch migration (`TODO.md`, container stack
+    // C2.4); the shape is only reachable inside a math *environment*, since the
+    // `$`/`\[` gates refuse a blank line themselves.
+    let src = "\\begin{equation}\n  \\left( \\left[ y\n\n  \\right] \\right)\n\\end{equation}\n";
+    let parsed = parse(src);
+    assert_eq!(parsed.syntax().to_string(), src);
+    assert!(
+        tree(src).contains("LEFT_RIGHT"),
+        "the outer pair is shielded from the break by the inner `\\left`"
+    );
+}
+
+#[test]
 fn left_right_pairs_inside_tikzcd_cell() {
     // `tikzcd` (tikz-cd commutative diagrams) typesets its cells in math mode, so
     // a `\left…\right` in a cell pairs into a `LEFT_RIGHT`. Same regression class

--- a/crates/badness-parser/tests/snapshots/parser__demoted_display_dollar_regates_its_second_dollar_as_inline.snap
+++ b/crates/badness-parser/tests/snapshots/parser__demoted_display_dollar_regates_its_second_dollar_as_inline.snap
@@ -1,0 +1,15 @@
+---
+source: crates/badness-parser/tests/parser.rs
+assertion_line: 1398
+expression: "tree(\"$$ a $\")"
+---
+ROOT@0..6
+  PARAGRAPH@0..6
+    DOLLAR@0..1 "$"
+    INLINE_MATH@1..6
+      DOLLAR@1..2 "$"
+      MATH@2..5
+        WHITESPACE@2..3 " "
+        WORD@3..4 "a"
+        WHITESPACE@4..5 " "
+      DOLLAR@5..6 "$"

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -287,9 +287,16 @@ real packages have: a `.sty` that defines `\bc`/`\ec` for its users and calls
 Every `Some` verdict names an index in the closer index, so the walk stops at
 the *last* closer in the file (none at all, and the gate refuses outright), and
 the verdict is memoized for the one opener the caller asks about twice —
-`starts_block_env` peeks before `element` dispatches. The adversarial residue —
-thousands of openers with a single closer at EOF — stays quadratic, the same
-recorded shape the conditional gate has.
+`starts_block_env` peeks before `element` dispatches.
+
+The gate runs on the shared batch driver (`AliasGate`), the conditional gate's
+second client, so the residual adversarial shape — thousands of openers with a
+single closer at EOF, where the last-closer bound spans the whole file and cuts
+nothing — is one linear pass rather than a scan per opener. Its two policy
+divergences from the conditional gate are the missing paragraph anchor above and
+the name match on the closer: nesting counts *any* alias opener and *any* alias
+closer, so `\bea \bce \ece \eea` pairs while the crossing `\bea \bce \eea \ece`
+refuses outright instead of letting an inner walk run past the outer bound.
 
 The node is the ordinary `ENVIRONMENT > BEGIN … END`, with the delimiters
 holding a bare `CONTROL_WORD` instead of `\begin` plus a `NAME_GROUP`, so every

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -255,6 +255,22 @@ per-opener pre-checks — the enclosing `group_depth`, and the `.dtx` doc-margin
 exemption — are walk state rather than scan state, so they are applied per query
 and never stored in a batch.
 
+The two **math** gates (`DollarGate`, `DelimMathGate`) run on the same driver,
+and for the uniformity rather than for speed: they are *single-entry*, opening
+no nested entry, so a batch settles its seed and nothing else. That is not a
+limitation but the shape of the problem — a delimiter whose closer is reachable
+swallows every opener up to it, so there is never a same-frame neighbor left to
+settle. Four policies invert with them. A `}` refuses unconditionally, where the
+pairing gates refuse only when a group actually encloses the opener, because the
+parse they guard bails at any unbalanced `}`. A foreign math delimiter is
+ordinary content — for the `$` gate it *is* the closer. Environments count at
+every brace depth, since a math body descends into a group and keeps parsing
+environments there. And the closer needs no environment balance, since a
+delimiter ends the body wherever it sits. The `$` gate is also the one gate that
+runs *unmemoized*: a demoted `$$` re-enters on its second `$`, asking a
+different question about the same token index under the same walk state, which a
+slot keyed on the walk state alone would answer from the first query's verdict.
+
 ### Environment aliases
 
 `\newcommand{\bea}{\begin{eqnarray}}` plus `\newcommand{\eea}{\end{eqnarray}}`

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -387,6 +387,16 @@ demoted it. Every ordinary anchor still cuts a scan short, so conditional-heavy
 real packages (`biblatex.sty`, `latexrelease.sty`, `memoir.cls`) measure the
 same as they did before the node existed.
 
+The batch is not the conditional gate's own machinery. It is a **driver**
+(`Parser::gate_batch`) that the other shape gates migrate onto one at a time
+(`TODO.md`, container stack C2): the driver owns the bookkeeping they all share
+— the bound, brace depth under `plain_braces`, environment counting, the
+`macrocode` frame, the entry stack with its settled-never-removed rule, the scan
+metering, and the walk-state memo — while each gate supplies a `GatePolicy`
+naming its own bound, its openers and closers, and whether a blank line anchors
+it. The divergences between gates are deliberate, so they stay visible as policy
+methods rather than being averaged into the loop.
+
 Two anchors differ from the environment gate on purpose. Running out of file
 demotes here, where the environment gate keeps the node so it can still report
 an unclosed environment; a conditional has no diagnostic to preserve. And there

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -500,9 +500,9 @@ metering, and the walk-state memo — while each gate supplies a `GatePolicy`
 naming its own bound, its openers and closers, and whether a blank line anchors
 it. The divergences between gates are deliberate, so they stay visible as policy
 methods rather than being averaged into the loop. With the bracket family
-migrated the driver serves all eight gates, and the policy surface is what the
+migrated the driver serves all nine gates, and the policy surface is what the
 migration bought: every place two gates read the same token differently is a
-named axis with a documented reason, where before it was eight hand
+named axis with a documented reason, where before it was nine hand
 transcriptions in which a fix to one copy did not propagate (issue #95).
 
 Two anchors differ from the environment gate on purpose. Running out of file

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -297,6 +297,48 @@ math like `$\left#2\right#4$` lives (issue #95). On the driver that is two
 predicates in a policy; as a hand-written scan it was a comment nothing
 enforced.
 
+The **bracket family** closes the migration: three gates (`TextBracketGate`,
+`MathBracketGate`, `MacrocodeBracketGate`) asking whether a `[`'s `]` is
+reachable before the token that would make the `optional` walk bail, in text, in
+math, and inside a `macrocode` chunk. Their nesting turned out to need no new
+model. A per-opener bracket scan counts the `]`s *owed* to the command-abutting
+`[`s it passes — such a `[` is itself argument-shaped and will claim the next
+`]` when parsed, so that `]` cannot also satisfy the outer one (issue #55) — and
+that claim countdown **is** the driver's nested-opener stack once an opener is
+defined as a command-abutting `[`, since closer matching is LIFO either way.
+
+What is new is that both of the family's anchors are depth-**blind**: a
+`\begin`/`\end` refuses rather than counts (an optional never legitimately spans
+an environment, so either half means a runaway `[`), and it and the paragraph
+break fire at any brace depth. Both follow from the walk they guard: `optional`
+bails wherever the cursor stands, and a gate stricter *or* looser than its parse
+is a bug.
+
+Two things are the in-math gate's own. A `$` there is read from the enclosing
+math's *flavor*, which is walk state and so rides the batch's memo key: inside
+`\[…\]` a `$` opens a genuine nested inline region, so a balanced `$…$` in the
+bracket is **transparent** — the entries' own openers and closers stop counting
+until the matching `$`, and everything else reads on — while inside `$…$` TeX
+cannot nest one, so the first `$` at the bracket's own level is that math's
+closer and refuses. And the gate is stricter than the `optional` bail in two
+preserved respects: its `\begin`/`\end` anchor carries no `in_macro_code`
+filter, and a chunk-unmatched brace is group structure to it rather than a plain
+token. Both only ever decline to attach. The second is arguably the *faithful*
+reading — `optional` itself bails at any `R_BRACE` without consulting
+`plain_braces`, so its two siblings, which do consult it, are the loose ones —
+but unifying either way moves verdicts and is its own commit.
+
+The `macrocode` gate diverges once more, and the corpora care: it skips only
+whitespace in its paragraph run, so a docstrip guard line **breaks** the run
+where every other gate floats it. That is the `saw_blank_line_outside_guards`
+reading (docstrip *deletes* a guard-only line, so it does not part what
+surrounds it, issue #71), and `rotating.dtx` depends on it — the date optional
+of its `\ProvidesPackage` runs over three guard lines inside one chunk, and
+floating them would read the newlines around a guard-only line as a blank line
+and drop the argument. It is also the one bracket gate the batch cannot make
+linear: single-entry by policy, so a chunk of `\cmd[` openers whose only `]`
+sits past the frame still scans to the frame per opener.
+
 ### Environment aliases
 
 `\newcommand{\bea}{\begin{eqnarray}}` plus `\newcommand{\eea}{\end{eqnarray}}`
@@ -457,7 +499,11 @@ The batch is not the conditional gate's own machinery. It is a **driver**
 metering, and the walk-state memo — while each gate supplies a `GatePolicy`
 naming its own bound, its openers and closers, and whether a blank line anchors
 it. The divergences between gates are deliberate, so they stay visible as policy
-methods rather than being averaged into the loop.
+methods rather than being averaged into the loop. With the bracket family
+migrated the driver serves all eight gates, and the policy surface is what the
+migration bought: every place two gates read the same token differently is a
+named axis with a documented reason, where before it was eight hand
+transcriptions in which a fix to one copy did not propagate (issue #95).
 
 Two anchors differ from the environment gate on purpose. Running out of file
 demotes here, where the environment gate keeps the node so it can still report

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -242,6 +242,19 @@ environment alias pairs only when its closer is positively located. All four
 degrade to a plain token with no diagnostic, because parser diagnostics gate the
 formatter and so must be high precision.
 
+The `\begin` gate runs on the shared batch driver as `EnvGate`, and it is the
+first *demotion* gate there, so its policy reads inverted: the located "closer"
+is the escaping `}`, `Some` demotes the environment and `None` keeps it, and
+running out of file is not an escape — that is what keeps the
+unclosed-environment diagnostic firing on a forgotten `\end`. Two consequences
+follow. A stray `}` closes rather than refutes, the same token event the
+positive gates read as a refusal. And a math delimiter is not an anchor at all:
+for a positive gate, declining behind one is the conservative direction, while
+here it would *keep* an environment the scan cannot vouch for. The gate's two
+per-opener pre-checks — the enclosing `group_depth`, and the `.dtx` doc-margin
+exemption — are walk state rather than scan state, so they are applied per query
+and never stored in a batch.
+
 ### Environment aliases
 
 `\newcommand{\bea}{\begin{eqnarray}}` plus `\newcommand{\eea}{\end{eqnarray}}`

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -271,6 +271,32 @@ runs *unmemoized*: a demoted `$$` re-enters on its second `$`, asking a
 different question about the same token index under the same walk state, which a
 slot keyed on the walk state alone would answer from the first query's verdict.
 
+The `\left…\right` gate (`LeftRightGate`) is the last to join, and the only one
+whose entries **stack** rather than count. Every other gate models its nesting
+as two independent counters — how many nested openers and how many environments
+stand between an entry and the token at hand — because that is all its
+per-opener scan ever knew. A `\left` pairs by count wherever it sits, so its
+scan reads one LIFO stack of `{`, `\begin`, and `\left` frames alike, and the
+difference is visible: a frame **mismatch** (an `\end` or a `\right` that
+reaches a frame of the wrong kind) is seen by every outer `\left` too, since the
+innermost frame is common to all of them, so it refuses the whole scan rather
+than one level of it — while the *absence* of frames that the blank-line anchor
+tests is seen only by the innermost `\left`, so a nested pair **shields** the
+ones around it from a paragraph break. Both readings are `Nesting::Interleaved`
+in the driver.
+
+Its math anchor inverts too. A conditional lives in text, so what defeats it is
+math *starting*; a `\left` already lives inside a math body, so what defeats it
+is that body *ending* — `$`, `\]`, `\)`, exactly the recovery anchors of the
+`left_right` walk it guards, while a `\[` in the way is ordinary content. And it
+is the gate whose opener and closer recognition **ignores `in_macro_code` on
+purpose** where the driver's own `\begin`/`\end` counting does not:
+`\left`/`\right` are catcode-neutral math structure that pairs by count no
+matter what, and a `\def` body or a `macrocode` chunk is exactly where package
+math like `$\left#2\right#4$` lives (issue #95). On the driver that is two
+predicates in a policy; as a hand-written scan it was a comment nothing
+enforced.
+
 ### Environment aliases
 
 `\newcommand{\bea}{\begin{eqnarray}}` plus `\newcommand{\eea}{\end{eqnarray}}`

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -370,13 +370,22 @@ command. The tree is still well formed and still lossless, which is the bar; but
 it is why `ast::Conditional::closer` is fallible and why no consumer may assume
 the scan's index and the walk's agree.
 
-The cost is one forward scan per live opener. Every ordinary anchor cuts it
-short, so conditional-heavy real packages (`biblatex.sty`, `latexrelease.sty`,
-`memoir.cls`) measure the same as they did before the node existed. The shape
-that does not cut short is thousands of top-level openers with no blank line, no
-unbalanced brace, and no reachable `\fi`, which is quadratic; no corpus file
-hits it, and the linear rewrite is recorded in `TODO.md` against the day one
-does.
+The cost is one forward scan per *batch*, not per opener. The scan is bounded by
+the last `\fi`-flavored word in the file (a file with none refuses without
+scanning), and one scan settles every opener it passes in the seed's own brace
+frame: nested openers are only counted at brace depth zero, so they share the
+seed's frame exactly and `\fi` matching is pure LIFO over a pending stack. The
+batch is memoized against the walk state the scan read (`macrocode_end`,
+`in_def_body`, whether a group encloses), so a run of top-level openers costs
+one linear pass where it used to cost one scan each — the quadratic
+thousands-of-openers shape recorded here before the batch now measures in the
+tens of milliseconds. One rule in the batch is load-bearing: a refuted entry is
+settled, never removed, because the per-opener scan counts nested openers by
+name and never un-counts one — a later `\fi` must still be consumed by the
+refuted entry's slot, or the outer opener would pair where the per-opener scan
+demoted it. Every ordinary anchor still cuts a scan short, so conditional-heavy
+real packages (`biblatex.sty`, `latexrelease.sty`, `memoir.cls`) measure the
+same as they did before the node existed.
 
 Two anchors differ from the environment gate on purpose. Running out of file
 demotes here, where the environment gate keeps the node so it can still report

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,9 +289,23 @@ fn run_debug_echo_args(out: &Path, args: &[String]) -> ExitCode {
     if !args.is_empty() {
         body.push('\n');
     }
-    match std::fs::write(out, body) {
+    // Stage and rename rather than writing `out` in place. The test polling for
+    // this recording lives in *another process* (the viewer runs detached), and
+    // a plain `fs::write` leaves the file existing-and-empty between its
+    // truncate and its write. A reader landing in that window reads back a
+    // complete-looking recording of zero arguments, which is indistinguishable
+    // from a viewer launched with none — the flake behind an `assert_eq!` whose
+    // left side was `[]`. A rename within one directory is atomic, so the
+    // reader sees either no file at all or the entire recording.
+    let staging = out.with_file_name(format!(
+        "{}.{}.tmp",
+        out.file_name().unwrap_or_default().to_string_lossy(),
+        std::process::id()
+    ));
+    match std::fs::write(&staging, body).and_then(|()| std::fs::rename(&staging, out)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
+            let _ = std::fs::remove_file(&staging);
             eprintln!("badness: failed to write {}: {err}", out.display());
             ExitCode::from(2)
         }

--- a/tests/gate_baselines/latexindent.trivia.txt
+++ b/tests/gate_baselines/latexindent.trivia.txt
@@ -7,7 +7,6 @@
 ./test-cases/alignment/issue-207-mod0.tex	format-error	format-error
 ./test-cases/alignment/issue-207-mod1.tex	format-error	format-error
 ./test-cases/alignment/issue-207.tex	format-error	format-error
-./test-cases/benchmarks/paperSS122018arxivv2-mod1.tex	trivia	non-fixed-point
 ./test-cases/benchmarks/sampleBEFORE-smaller.tex	format-error	format-error
 ./test-cases/broken/broken-mod1.tex	format-error	format-error
 ./test-cases/broken/broken-mod2.tex	format-error	format-error


### PR DESCRIPTION
**What and why**

The parser's shape gates (`\if`/`\fi`, environment aliases, `\begin`
brace-escape, `$`, `\[`/`\(`, `\left`/`\right`, and the three bracket
gates) were nine hand-written per-opener scans, each carrying its own copy
of the same bookkeeping: the scan bound, brace depth under `plain_braces`,
environment counting, the `macrocode` frame, the nesting stack. A fix to
one copy did not propagate to the others (#95), and several were quadratic
on a run of same-frame openers.

This branch bounds every gate by its last-closer index, then extracts the
bookkeeping into one driver (`Parser::gate_batch`) and migrates all nine
scans onto it. One forward scan seeded at the queried opener now settles
every same-frame opener it passes, memoized against the walk state it read.

Roadmap: `TODO.md`, container stack C0 through C3 (all closed by this
branch).

Speed, `parse` alone, N openers with a single reachable closer at EOF, at
1000/2000/4000:

| gate | before | after |
| --- | --- | --- |
| `conditional_closer` | quadratic | linear |
| `alias_closer` | 15/59/192ms | 9/18/46ms |
| `left_right_closes` | 3.9/14.6/57.0ms | 0.39/1.0/1.6ms |
| `bracket_closes_in_text` | 3.2/12.4/50.5ms | 0.29/0.56/1.16ms |
| `bracket_closes_before_math_end` | 1.8/9.4/28.9ms | 0.39/0.59/1.19ms |

The *constant* factor needed a follow-up commit. As first written the
driver allocated per gate query — a `HashMap` for every scan, holding one
verdict for the three single-entry gates — and ticked a scan counter per
token in release builds. That cost ~2% of parse time, same-signed on all
four bench documents, which is small but not noise. Single-entry gates
now collect into a slot, a memo miss recycles the superseded batch's
storage, and the counter is `cfg(test)`.

`bench:micro` against `main`, medians of 7 back-to-back samples, parse
only:

| doc | main | branch |
| --- | --- | --- |
| small.tex | 31.3 us | 31.4 us |
| cv.tex | 116.1 us | 118.5 us |
| masters_dissertation.tex | 3.65 ms | 3.68 ms |
| phd_dissertation.tex | 36.10 ms | 35.78 ms |

The two large documents are the trustworthy rows; `cv.tex` is 6 KB and
its own run-to-run spread (115-133 us) is wider than the delta, so I
would not read a regression into it.

**Approach**

The driver owns only the *bookkeeping*. Each gate supplies a `GatePolicy`
naming its own bound, openers, closers, and anchors. **The driver never
averages two gates' policies**: where they read the same token
differently, the divergence is a named axis with the reason attached, and
the doc says whether it was *chosen* or *preserved from the pre-batch
scan*. That distinction is the point of the exercise, and it turned two
previously invisible accidents into testable facts.

Migration technique, per gate: keep the old per-opener scan as a
`#[cfg(debug_assertions)]` shadow reference and assert
`batch(open) == reference(open)` on every query, run the suite plus a
per-file debug-assertions pass over all 6277 corpus files, then delete the
reference. Verdicts are bit-identical to the pre-batch scans, which is a
stronger claim than the gates' own one-directional contract and is what
makes the migration mechanically checkable.

Notes for reviewers:

- **The policy surface is wide**: 16 axes over 9 gates, 5 of them set by
  exactly one gate. That is deliberate (see above) but it is the main
  thing to push back on if you disagree with the shape.
- **Three preserved divergences are recorded, not endorsed.** Flipping
  each one against the corpora was mechanical once it had a name: five of
  six are invisible to all 6277 files, and one is load-bearing —
  `DOC_TRIVIA_FLOATS`, where the `macrocode` bracket gate breaks its
  paragraph run at a docstrip guard line while every other gate floats
  one. That is the considered #71 reading (docstrip *deletes* a guard-only
  line), and `rotating.dtx`'s `\ProvidesPackage` date optional depends on
  it. So the other seven gates are the ones diverging from the model, and
  unification should move toward this gate; recorded as a follow-up in
  `TODO.md` rather than smuggled in here.
- **Two shapes stay quadratic by design** and say so in their tests rather
  than pretending otherwise: a `${` per line (brace depth ratchets upward,
  so no later opener sits at the seed's level) and a `macrocode` chunk of
  `\cmd[` openers whose only `]` is past the frame (that gate is
  single-entry by policy).
- **`bracket_closes_before_math_end` was the only unbounded gate** the C0
  survey turned up beyond the two originally named; its memo key had to
  grow the enclosing math's flavor, since nothing else in `WalkKey` moves
  when that does.

**Checklist**

- [x] Added or updated tests (test-first; a bug fix has a failing fixture that now passes)
- [x] New parser features have corpus + snapshot tests and a losslessness assertion
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt -- --check` is clean
- [x] Reviewed changed snapshots (`cargo insta review`), if any
- [x] Commits follow Conventional Commits

Also green: `task gate-corpora:check` (all eight baselines, two-sided
ratchet), `task parse-compat` and `task bib-parse-compat` unchanged — a
verdict-preserving migration must not move the differential.

