### PR TITLE
chore(release): v0.17.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "efcf3e6a03fe5f91d00329d616db70be58e4a400",
+  "baseline-sha": "7d39e61cd3854c41c43ef7c4cee938c968259a2b",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.3.0",
-      "tag": "badness-formatter-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-formatter-v0.4.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.2.0",
-      "tag": "badness-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "badness-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "badness-code-v0.16.0"
+      "version": "0.17.0",
+      "tag": "badness-code-v0.17.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.3.0",
-      "tag": "badness-formatter-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-formatter-v0.4.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.2.0",
-      "tag": "badness-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "badness-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "badness-code-v0.16.0"
+      "version": "0.17.0",
+      "tag": "badness-code-v0.17.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/badness/compare/v0.16.0...v0.17.0) (2026-08-20)
+
+### Breaking changes
+- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+
+### Features
+- **formatter:** format DTX doc environments ([`ac98c95`](https://github.com/jolars/badness/commit/ac98c9564f4e7a4082cc7fe2be0fa3a3c3e678a3)), fixes [#127](https://github.com/jolars/badness/issues/127)
+- **parser:** intra-file incremental reparse (#130) ([`393e0c3`](https://github.com/jolars/badness/commit/393e0c3e85b10226e58afb7b37f78cfe535dd9fd))
+- **bench:** time the keystroke pipeline ([`b1b2b0e`](https://github.com/jolars/badness/commit/b1b2b0e1edf3d8952248e25c41c113047bcd7a97))
+- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
+- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))
+
+### Bug Fixes
+- **parser:** isolate command definition names ([`8d6e274`](https://github.com/jolars/badness/commit/8d6e274957da4781668e25d9f2cd8261ee87cd34)), fixes [#133](https://github.com/jolars/badness/issues/133)
+- **formatter:** preserve TeX line semantics ([`f16188b`](https://github.com/jolars/badness/commit/f16188b5adb7b0132a58dbc05fcd435456843c3b)), fixes [#132](https://github.com/jolars/badness/issues/132)
+- **formatter:** handle mixed dtx doc regions ([`6edfd81`](https://github.com/jolars/badness/commit/6edfd81f713baa6118838e23d79edbce0653fa76)), fixes [#126](https://github.com/jolars/badness/issues/126)
+- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
+- **formatter:** preserve guarded dtx paragraphs ([`0373420`](https://github.com/jolars/badness/commit/03734200431df441c48c706444633df287e26542)), fixes [#123](https://github.com/jolars/badness/issues/123)
+
+### Performance Improvements
+- **lsp:** share document text and line index ([`3d4a5f8`](https://github.com/jolars/badness/commit/3d4a5f89e89cb371e6648b7a6226eb633c97af8e))
+
+### Dependencies
+- updated crates/badness-formatter to v0.4.0
+- updated crates/badness-parser to v0.3.0
+
 ## [0.16.0](https://github.com/jolars/badness/compare/v0.15.0...v0.16.0) (2026-08-14)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -114,7 +114,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "similar 3.1.2",
+ "similar 3.2.0",
  "smol_str",
  "tempfile",
  "toml",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "parser",
@@ -606,9 +606,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -901,18 +901,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,9 +1199,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"
@@ -46,8 +46,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.3.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.2.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.4.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.3.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/badness/compare/badness-formatter-v0.3.0...badness-formatter-v0.4.0) (2026-08-20)
+
+### Breaking changes
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+
+### Features
+- **formatter:** format DTX doc environments ([`ac98c95`](https://github.com/jolars/badness/commit/ac98c9564f4e7a4082cc7fe2be0fa3a3c3e678a3)), fixes [#127](https://github.com/jolars/badness/issues/127)
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
+- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))
+- **parser:** wrap picture-body statements in STATEMENT nodes ([`abb16f4`](https://github.com/jolars/badness/commit/abb16f4948aea7e275cdba622ab4571701cd7682))
+
+### Bug Fixes
+- **formatter:** preserve verbatim arguments ([`7d39e61`](https://github.com/jolars/badness/commit/7d39e61cd3854c41c43ef7c4cee938c968259a2b)), fixes [#134](https://github.com/jolars/badness/issues/134)
+- **formatter:** preserve TeX line semantics ([`f16188b`](https://github.com/jolars/badness/commit/f16188b5adb7b0132a58dbc05fcd435456843c3b)), fixes [#132](https://github.com/jolars/badness/issues/132)
+- **formatter:** handle mixed dtx doc regions ([`6edfd81`](https://github.com/jolars/badness/commit/6edfd81f713baa6118838e23d79edbce0653fa76)), fixes [#126](https://github.com/jolars/badness/issues/126)
+- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
+- **formatter:** preserve DTX margin semantics ([`5dc60ec`](https://github.com/jolars/badness/commit/5dc60ecf24ab42152a2ae052c9f4fd615a966c5f)), fixes [#125](https://github.com/jolars/badness/issues/125)
+- **formatter:** stabilize DTX prose atoms ([`35164ab`](https://github.com/jolars/badness/commit/35164ab7e008df1ead9c54886d4cf3bc74e35fbf)), fixes [#128](https://github.com/jolars/badness/issues/128)
+- **formatter:** preserve guarded dtx paragraphs ([`0373420`](https://github.com/jolars/badness/commit/03734200431df441c48c706444633df287e26542)), fixes [#123](https://github.com/jolars/badness/issues/123)
+- **formatter:** preserve guarded dtx commands ([`3d5d7ea`](https://github.com/jolars/badness/commit/3d5d7eaf2eac254bcff86b91bfe6103e36b548fd)), ref [#122](https://github.com/jolars/badness/issues/122)
+- fix formatter keyval separator idempotency ([`3d6ffa7`](https://github.com/jolars/badness/commit/3d6ffa7398053783709456c6f467ca3ec2873a81)), closes [#121](https://github.com/jolars/badness/issues/121)
+- **formatter:** retain math environment begin tails ([`2af7cb1`](https://github.com/jolars/badness/commit/2af7cb1aa5b1f6524a7274ed5eacdbac89197e94))
+
+### Dependencies
+- updated crates/badness-parser to v0.3.0
+
 ## [0.3.0](https://github.com/jolars/badness/compare/badness-formatter-v0.2.0...badness-formatter-v0.3.0) (2026-08-14)
 
 ### Features

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for LaTeX and BibTeX"
@@ -14,7 +14,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.2.0" }
+badness-parser = { path = "../badness-parser", version = "0.3.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/badness/compare/badness-parser-v0.2.0...badness-parser-v0.3.0) (2026-08-20)
+
+### Breaking changes
+- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+
+### Features
+- **parser:** intra-file incremental reparse (#130) ([`393e0c3`](https://github.com/jolars/badness/commit/393e0c3e85b10226e58afb7b37f78cfe535dd9fd))
+- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
+- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
+- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
+- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))
+- **parser:** wrap picture-body statements in STATEMENT nodes ([`abb16f4`](https://github.com/jolars/badness/commit/abb16f4948aea7e275cdba622ab4571701cd7682))
+
+### Bug Fixes
+- **parser:** isolate command definition names ([`8d6e274`](https://github.com/jolars/badness/commit/8d6e274957da4781668e25d9f2cd8261ee87cd34)), fixes [#133](https://github.com/jolars/badness/issues/133)
+- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
+- add ControlSequence ([`c2fb13d`](https://github.com/jolars/badness/commit/c2fb13d1190ff9aa7da5eca94e531059a751da21))
+- **parser:** preserve def dollar delimiters ([`2381bc5`](https://github.com/jolars/badness/commit/2381bc56a3ff38ee9284e50ce33a962fc5881eae)), fixes [#129](https://github.com/jolars/badness/issues/129)
+
 ## [0.2.0](https://github.com/jolars/badness/compare/badness-parser-v0.1.1...badness-parser-v0.2.0) (2026-08-14)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, semantic model, and command-signature database for LaTeX and BibTeX"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/badness/compare/badness-code-v0.16.0...badness-code-v0.17.0) (2026-08-20)
+
+### Dependencies
+- updated badness to v0.17.0
+
 ## [0.16.0](https://github.com/jolars/badness/compare/badness-code-v0.15.0...badness-code-v0.16.0) (2026-08-14)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.16.0",
-    "@badness/linux-arm64-gnu": "0.16.0",
-    "@badness/linux-x64-musl": "0.16.0",
-    "@badness/linux-arm64-musl": "0.16.0",
-    "@badness/darwin-x64": "0.16.0",
-    "@badness/darwin-arm64": "0.16.0",
-    "@badness/win32-x64": "0.16.0",
-    "@badness/win32-arm64": "0.16.0"
+    "@badness/linux-x64-gnu": "0.17.0",
+    "@badness/linux-arm64-gnu": "0.17.0",
+    "@badness/linux-x64-musl": "0.17.0",
+    "@badness/linux-arm64-musl": "0.17.0",
+    "@badness/darwin-x64": "0.17.0",
+    "@badness/darwin-arm64": "0.17.0",
+    "@badness/win32-x64": "0.17.0",
+    "@badness/win32-arm64": "0.17.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.17.0](https://github.com/jolars/badness/compare/v0.16.0...v0.17.0) (2026-08-20)

### Breaking changes
- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))

### Features
- **formatter:** format DTX doc environments ([`ac98c95`](https://github.com/jolars/badness/commit/ac98c9564f4e7a4082cc7fe2be0fa3a3c3e678a3)), fixes [#127](https://github.com/jolars/badness/issues/127)
- **parser:** intra-file incremental reparse (#130) ([`393e0c3`](https://github.com/jolars/badness/commit/393e0c3e85b10226e58afb7b37f78cfe535dd9fd))
- **bench:** time the keystroke pipeline ([`b1b2b0e`](https://github.com/jolars/badness/commit/b1b2b0e1edf3d8952248e25c41c113047bcd7a97))
- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))

### Bug Fixes
- **parser:** isolate command definition names ([`8d6e274`](https://github.com/jolars/badness/commit/8d6e274957da4781668e25d9f2cd8261ee87cd34)), fixes [#133](https://github.com/jolars/badness/issues/133)
- **formatter:** preserve TeX line semantics ([`f16188b`](https://github.com/jolars/badness/commit/f16188b5adb7b0132a58dbc05fcd435456843c3b)), fixes [#132](https://github.com/jolars/badness/issues/132)
- **formatter:** handle mixed dtx doc regions ([`6edfd81`](https://github.com/jolars/badness/commit/6edfd81f713baa6118838e23d79edbce0653fa76)), fixes [#126](https://github.com/jolars/badness/issues/126)
- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
- **formatter:** preserve guarded dtx paragraphs ([`0373420`](https://github.com/jolars/badness/commit/03734200431df441c48c706444633df287e26542)), fixes [#123](https://github.com/jolars/badness/issues/123)

### Performance Improvements
- **lsp:** share document text and line index ([`3d4a5f8`](https://github.com/jolars/badness/commit/3d4a5f89e89cb371e6648b7a6226eb633c97af8e))

### Dependencies
- updated crates/badness-formatter to v0.4.0
- updated crates/badness-parser to v0.3.0

## [crates/badness-formatter: 0.4.0](https://github.com/jolars/badness/compare/badness-formatter-v0.3.0...badness-formatter-v0.4.0) (2026-08-20)

### Breaking changes
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))

### Features
- **formatter:** format DTX doc environments ([`ac98c95`](https://github.com/jolars/badness/commit/ac98c9564f4e7a4082cc7fe2be0fa3a3c3e678a3)), fixes [#127](https://github.com/jolars/badness/issues/127)
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))
- **parser:** wrap picture-body statements in STATEMENT nodes ([`abb16f4`](https://github.com/jolars/badness/commit/abb16f4948aea7e275cdba622ab4571701cd7682))

### Bug Fixes
- **formatter:** preserve verbatim arguments ([`7d39e61`](https://github.com/jolars/badness/commit/7d39e61cd3854c41c43ef7c4cee938c968259a2b)), fixes [#134](https://github.com/jolars/badness/issues/134)
- **formatter:** preserve TeX line semantics ([`f16188b`](https://github.com/jolars/badness/commit/f16188b5adb7b0132a58dbc05fcd435456843c3b)), fixes [#132](https://github.com/jolars/badness/issues/132)
- **formatter:** handle mixed dtx doc regions ([`6edfd81`](https://github.com/jolars/badness/commit/6edfd81f713baa6118838e23d79edbce0653fa76)), fixes [#126](https://github.com/jolars/badness/issues/126)
- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
- **formatter:** preserve DTX margin semantics ([`5dc60ec`](https://github.com/jolars/badness/commit/5dc60ecf24ab42152a2ae052c9f4fd615a966c5f)), fixes [#125](https://github.com/jolars/badness/issues/125)
- **formatter:** stabilize DTX prose atoms ([`35164ab`](https://github.com/jolars/badness/commit/35164ab7e008df1ead9c54886d4cf3bc74e35fbf)), fixes [#128](https://github.com/jolars/badness/issues/128)
- **formatter:** preserve guarded dtx paragraphs ([`0373420`](https://github.com/jolars/badness/commit/03734200431df441c48c706444633df287e26542)), fixes [#123](https://github.com/jolars/badness/issues/123)
- **formatter:** preserve guarded dtx commands ([`3d5d7ea`](https://github.com/jolars/badness/commit/3d5d7eaf2eac254bcff86b91bfe6103e36b548fd)), ref [#122](https://github.com/jolars/badness/issues/122)
- fix formatter keyval separator idempotency ([`3d6ffa7`](https://github.com/jolars/badness/commit/3d6ffa7398053783709456c6f467ca3ec2873a81)), closes [#121](https://github.com/jolars/badness/issues/121)
- **formatter:** retain math environment begin tails ([`2af7cb1`](https://github.com/jolars/badness/commit/2af7cb1aa5b1f6524a7274ed5eacdbac89197e94))

### Dependencies
- updated crates/badness-parser to v0.3.0

## [crates/badness-parser: 0.3.0](https://github.com/jolars/badness/compare/badness-parser-v0.2.0...badness-parser-v0.3.0) (2026-08-20)

### Breaking changes
- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))

### Features
- **parser:** intra-file incremental reparse (#130) ([`393e0c3`](https://github.com/jolars/badness/commit/393e0c3e85b10226e58afb7b37f78cfe535dd9fd))
- **parser:** pair one-sided environment aliases ([`d757cdc`](https://github.com/jolars/badness/commit/d757cdca2dd65809ebd7f08f0e3e288e5036c45c)), closes [#117](https://github.com/jolars/badness/issues/117)
- **parser:** arity-directed expl3 attachment (#119) ([`5f2f9d8`](https://github.com/jolars/badness/commit/5f2f9d8d7d1abd93b054616e34ed07aa121da662))
- **formatter:** wrap picture statements at TikZ unit boundaries ([`5079f96`](https://github.com/jolars/badness/commit/5079f9607c5c8fcc9d021ba5b270347f7c6af524))
- **formatter:** hang statement continuations in picture bodies ([`5266aba`](https://github.com/jolars/badness/commit/5266aba65c4f0caa2cf5deebe8925ef70c9b9689))
- **parser:** wrap picture-body statements in STATEMENT nodes ([`abb16f4`](https://github.com/jolars/badness/commit/abb16f4948aea7e275cdba622ab4571701cd7682))

### Bug Fixes
- **parser:** isolate command definition names ([`8d6e274`](https://github.com/jolars/badness/commit/8d6e274957da4781668e25d9f2cd8261ee87cd34)), fixes [#133](https://github.com/jolars/badness/issues/133)
- preserve dtx documentation math ([`de0c54c`](https://github.com/jolars/badness/commit/de0c54cbedb2ae7cea6ab55204278fdd5bf2a49f)), fixes [#138](https://github.com/jolars/badness/issues/138)
- add ControlSequence ([`c2fb13d`](https://github.com/jolars/badness/commit/c2fb13d1190ff9aa7da5eca94e531059a751da21))
- **parser:** preserve def dollar delimiters ([`2381bc5`](https://github.com/jolars/badness/commit/2381bc56a3ff38ee9284e50ce33a962fc5881eae)), fixes [#129](https://github.com/jolars/badness/issues/129)

## [editors/code: 0.17.0](https://github.com/jolars/badness/compare/badness-code-v0.16.0...badness-code-v0.17.0) (2026-08-20)

### Dependencies
- updated badness to v0.17.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).