### PR TITLE
chore(release): v0.18.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7d39e61cd3854c41c43ef7c4cee938c968259a2b",
+  "baseline-sha": "67b39e2968756d1c88c43426db01574334091d70",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.4.0",
-      "tag": "badness-formatter-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-formatter-v0.5.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.3.0",
-      "tag": "badness-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "badness-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "badness-code-v0.18.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.4.0",
-      "tag": "badness-formatter-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-formatter-v0.5.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.3.0",
-      "tag": "badness-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "badness-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "badness-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "badness-code-v0.18.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/badness/compare/v0.17.0...v0.18.0) (2026-08-24)
+
+### Features
+- add LSP memory benchmark ([`9a975d7`](https://github.com/jolars/badness/commit/9a975d7dcee69bc143a90ecff041b36d5de356c2))
+- **formatter:** glue item overlays ([`e7b3efe`](https://github.com/jolars/badness/commit/e7b3efe42595e9c8f060b4700c79579981d90fc5))
+- **parser:** reparse math fragments ([`4638eb5`](https://github.com/jolars/badness/commit/4638eb5a644019235ef976420e58f47834354fc2))
+- **formatter:** unify math spacing ([`170da11`](https://github.com/jolars/badness/commit/170da11a42e15a730e8d5606ea2f4e7f87297185))
+- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
+- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))
+
+### Bug Fixes
+- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
+- **parser:** parse alignment char constants ([`78f3cd9`](https://github.com/jolars/badness/commit/78f3cd962b17379141efda3067495df8723f1b67))
+- **parser:** guard expl3 mode boundaries ([`08c0387`](https://github.com/jolars/badness/commit/08c0387ec0cad42ad04782d2175f5e61ef294fa3))
+- **formatter:** preserve trailing control newline ([`2a7977b`](https://github.com/jolars/badness/commit/2a7977b9083a3ff653c87c95768509cec27321f6)), fixes [#141](https://github.com/jolars/badness/issues/141)
+- **lsp:** replace project snapshot generations ([`a1194cb`](https://github.com/jolars/badness/commit/a1194cbcd54e33964e94081541fca1ab5fbc6141))
+- **lsp:** gate query logging ([`f212680`](https://github.com/jolars/badness/commit/f2126807582f78e8ed32b2d7b87ad9112cd0ec65))
+- **parser:** tighten catcode signal ([`834c7b6`](https://github.com/jolars/badness/commit/834c7b65b6ab319430e1ed86fdb62582f3b61812))
+- **parser:** pass plain braces through optionals ([`82b30f1`](https://github.com/jolars/badness/commit/82b30f17190f935432c3df59fc6428ed33003562))
+- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
+- **formatter:** preserve glued forced blocks ([`4938f6c`](https://github.com/jolars/badness/commit/4938f6c1a93cedf8ca6a5bfac592b839d5a28226))
+- **formatter:** align virtual dtx tables ([`e0a2cde`](https://github.com/jolars/badness/commit/e0a2cde90da208f5f7b8cad42987ee0ec8bd8099))
+- **parser:** preserve argument mode semantics ([`63aefa8`](https://github.com/jolars/badness/commit/63aefa8e626f9e7e1012ca02ab0370440441c5b2))
+- **formatter:** bound relation alignment ([`a560698`](https://github.com/jolars/badness/commit/a5606989918276da0d9579e7df9abddf2d4180e7))
+- **formatter:** preserve math line breaks ([`a1ad967`](https://github.com/jolars/badness/commit/a1ad9676f609c6664371e18365833280cda20018))
+- **parser:** honor TeX script atom boundaries ([`e6131b6`](https://github.com/jolars/badness/commit/e6131b69e1df9f3fed25af772fce803655b3e88d))
+
+### Dependencies
+- updated crates/badness-formatter to v0.5.0
+- updated crates/badness-parser to v0.4.0
+
 ## [0.17.0](https://github.com/jolars/badness/compare/v0.16.0...v0.17.0) (2026-08-20)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "parser",
@@ -282,7 +282,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -414,9 +414,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encode_unicode"
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -1031,7 +1031,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1186,7 +1186,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1273,7 +1273,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1297,7 +1297,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1436,7 +1436,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"
@@ -46,8 +46,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.4.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.3.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.5.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.4.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/badness/compare/badness-formatter-v0.4.0...badness-formatter-v0.5.0) (2026-08-24)
+
+### Features
+- **formatter:** glue item overlays ([`e7b3efe`](https://github.com/jolars/badness/commit/e7b3efe42595e9c8f060b4700c79579981d90fc5))
+- **formatter:** unify math spacing ([`170da11`](https://github.com/jolars/badness/commit/170da11a42e15a730e8d5606ea2f4e7f87297185))
+- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
+- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))
+
+### Bug Fixes
+- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
+- **formatter:** stabilize slash spacing ([`8f2e7ce`](https://github.com/jolars/badness/commit/8f2e7cee1140eb2e39a24211c963a70d50a34172)), fixes [#143](https://github.com/jolars/badness/issues/143)
+- **formatter:** preserve trailing control newline ([`2a7977b`](https://github.com/jolars/badness/commit/2a7977b9083a3ff653c87c95768509cec27321f6)), fixes [#141](https://github.com/jolars/badness/issues/141)
+- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
+- **formatter:** preserve glued forced blocks ([`4938f6c`](https://github.com/jolars/badness/commit/4938f6c1a93cedf8ca6a5bfac592b839d5a28226))
+- **formatter:** align virtual dtx tables ([`e0a2cde`](https://github.com/jolars/badness/commit/e0a2cde90da208f5f7b8cad42987ee0ec8bd8099))
+- **formatter:** bound relation alignment ([`a560698`](https://github.com/jolars/badness/commit/a5606989918276da0d9579e7df9abddf2d4180e7))
+- **formatter:** preserve math line breaks ([`a1ad967`](https://github.com/jolars/badness/commit/a1ad9676f609c6664371e18365833280cda20018))
+
+### Dependencies
+- updated crates/badness-parser to v0.4.0
+
 ## [0.4.0](https://github.com/jolars/badness/compare/badness-formatter-v0.3.0...badness-formatter-v0.4.0) (2026-08-20)
 
 ### Breaking changes

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for LaTeX and BibTeX"
@@ -14,7 +14,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.3.0" }
+badness-parser = { path = "../badness-parser", version = "0.4.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/badness/compare/badness-parser-v0.3.0...badness-parser-v0.4.0) (2026-08-24)
+
+### Features
+- add LSP memory benchmark ([`9a975d7`](https://github.com/jolars/badness/commit/9a975d7dcee69bc143a90ecff041b36d5de356c2))
+- **parser:** reparse math fragments ([`4638eb5`](https://github.com/jolars/badness/commit/4638eb5a644019235ef976420e58f47834354fc2))
+- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
+- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))
+
+### Bug Fixes
+- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
+- **parser:** parse alignment char constants ([`78f3cd9`](https://github.com/jolars/badness/commit/78f3cd962b17379141efda3067495df8723f1b67))
+- **parser:** guard expl3 mode boundaries ([`08c0387`](https://github.com/jolars/badness/commit/08c0387ec0cad42ad04782d2175f5e61ef294fa3))
+- **parser:** unwind environment gate mismatches ([`6398829`](https://github.com/jolars/badness/commit/6398829dde0e22ed7680ca270f846fffd30c5d8d))
+- **parser:** gate math environments in groups ([`b221ccd`](https://github.com/jolars/badness/commit/b221ccda0f983ad3ce512d59d8152f63b667a2ad))
+- **parser:** tighten catcode signal ([`834c7b6`](https://github.com/jolars/badness/commit/834c7b65b6ab319430e1ed86fdb62582f3b61812))
+- **parser:** pass plain braces through optionals ([`82b30f1`](https://github.com/jolars/badness/commit/82b30f17190f935432c3df59fc6428ed33003562))
+- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
+- **parser:** preserve argument mode semantics ([`63aefa8`](https://github.com/jolars/badness/commit/63aefa8e626f9e7e1012ca02ab0370440441c5b2))
+- **parser:** honor TeX script atom boundaries ([`e6131b6`](https://github.com/jolars/badness/commit/e6131b69e1df9f3fed25af772fce803655b3e88d))
+
 ## [0.3.0](https://github.com/jolars/badness/compare/badness-parser-v0.2.0...badness-parser-v0.3.0) (2026-08-20)
 
 ### Breaking changes

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, semantic model, and command-signature database for LaTeX and BibTeX"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/badness/compare/badness-code-v0.17.0...badness-code-v0.18.0) (2026-08-24)
+
+### Dependencies
+- updated badness to v0.18.0
+
 ## [0.17.0](https://github.com/jolars/badness/compare/badness-code-v0.16.0...badness-code-v0.17.0) (2026-08-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.17.0",
-    "@badness/linux-arm64-gnu": "0.17.0",
-    "@badness/linux-x64-musl": "0.17.0",
-    "@badness/linux-arm64-musl": "0.17.0",
-    "@badness/darwin-x64": "0.17.0",
-    "@badness/darwin-arm64": "0.17.0",
-    "@badness/win32-x64": "0.17.0",
-    "@badness/win32-arm64": "0.17.0"
+    "@badness/linux-x64-gnu": "0.18.0",
+    "@badness/linux-arm64-gnu": "0.18.0",
+    "@badness/linux-x64-musl": "0.18.0",
+    "@badness/linux-arm64-musl": "0.18.0",
+    "@badness/darwin-x64": "0.18.0",
+    "@badness/darwin-arm64": "0.18.0",
+    "@badness/win32-x64": "0.18.0",
+    "@badness/win32-arm64": "0.18.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.18.0](https://github.com/jolars/badness/compare/v0.17.0...v0.18.0) (2026-08-24)

### Features
- add LSP memory benchmark ([`9a975d7`](https://github.com/jolars/badness/commit/9a975d7dcee69bc143a90ecff041b36d5de356c2))
- **formatter:** glue item overlays ([`e7b3efe`](https://github.com/jolars/badness/commit/e7b3efe42595e9c8f060b4700c79579981d90fc5))
- **parser:** reparse math fragments ([`4638eb5`](https://github.com/jolars/badness/commit/4638eb5a644019235ef976420e58f47834354fc2))
- **formatter:** unify math spacing ([`170da11`](https://github.com/jolars/badness/commit/170da11a42e15a730e8d5606ea2f4e7f87297185))
- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))

### Bug Fixes
- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
- **parser:** parse alignment char constants ([`78f3cd9`](https://github.com/jolars/badness/commit/78f3cd962b17379141efda3067495df8723f1b67))
- **parser:** guard expl3 mode boundaries ([`08c0387`](https://github.com/jolars/badness/commit/08c0387ec0cad42ad04782d2175f5e61ef294fa3))
- **formatter:** preserve trailing control newline ([`2a7977b`](https://github.com/jolars/badness/commit/2a7977b9083a3ff653c87c95768509cec27321f6)), fixes [#141](https://github.com/jolars/badness/issues/141)
- **lsp:** replace project snapshot generations ([`a1194cb`](https://github.com/jolars/badness/commit/a1194cbcd54e33964e94081541fca1ab5fbc6141))
- **lsp:** gate query logging ([`f212680`](https://github.com/jolars/badness/commit/f2126807582f78e8ed32b2d7b87ad9112cd0ec65))
- **parser:** tighten catcode signal ([`834c7b6`](https://github.com/jolars/badness/commit/834c7b65b6ab319430e1ed86fdb62582f3b61812))
- **parser:** pass plain braces through optionals ([`82b30f1`](https://github.com/jolars/badness/commit/82b30f17190f935432c3df59fc6428ed33003562))
- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
- **formatter:** preserve glued forced blocks ([`4938f6c`](https://github.com/jolars/badness/commit/4938f6c1a93cedf8ca6a5bfac592b839d5a28226))
- **formatter:** align virtual dtx tables ([`e0a2cde`](https://github.com/jolars/badness/commit/e0a2cde90da208f5f7b8cad42987ee0ec8bd8099))
- **parser:** preserve argument mode semantics ([`63aefa8`](https://github.com/jolars/badness/commit/63aefa8e626f9e7e1012ca02ab0370440441c5b2))
- **formatter:** bound relation alignment ([`a560698`](https://github.com/jolars/badness/commit/a5606989918276da0d9579e7df9abddf2d4180e7))
- **formatter:** preserve math line breaks ([`a1ad967`](https://github.com/jolars/badness/commit/a1ad9676f609c6664371e18365833280cda20018))
- **parser:** honor TeX script atom boundaries ([`e6131b6`](https://github.com/jolars/badness/commit/e6131b69e1df9f3fed25af772fce803655b3e88d))

### Dependencies
- updated crates/badness-formatter to v0.5.0
- updated crates/badness-parser to v0.4.0

## [crates/badness-formatter: 0.5.0](https://github.com/jolars/badness/compare/badness-formatter-v0.4.0...badness-formatter-v0.5.0) (2026-08-24)

### Features
- **formatter:** glue item overlays ([`e7b3efe`](https://github.com/jolars/badness/commit/e7b3efe42595e9c8f060b4700c79579981d90fc5))
- **formatter:** unify math spacing ([`170da11`](https://github.com/jolars/badness/commit/170da11a42e15a730e8d5606ea2f4e7f87297185))
- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))

### Bug Fixes
- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
- **formatter:** stabilize slash spacing ([`8f2e7ce`](https://github.com/jolars/badness/commit/8f2e7cee1140eb2e39a24211c963a70d50a34172)), fixes [#143](https://github.com/jolars/badness/issues/143)
- **formatter:** preserve trailing control newline ([`2a7977b`](https://github.com/jolars/badness/commit/2a7977b9083a3ff653c87c95768509cec27321f6)), fixes [#141](https://github.com/jolars/badness/issues/141)
- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
- **formatter:** preserve glued forced blocks ([`4938f6c`](https://github.com/jolars/badness/commit/4938f6c1a93cedf8ca6a5bfac592b839d5a28226))
- **formatter:** align virtual dtx tables ([`e0a2cde`](https://github.com/jolars/badness/commit/e0a2cde90da208f5f7b8cad42987ee0ec8bd8099))
- **formatter:** bound relation alignment ([`a560698`](https://github.com/jolars/badness/commit/a5606989918276da0d9579e7df9abddf2d4180e7))
- **formatter:** preserve math line breaks ([`a1ad967`](https://github.com/jolars/badness/commit/a1ad9676f609c6664371e18365833280cda20018))

### Dependencies
- updated crates/badness-parser to v0.4.0

## [crates/badness-parser: 0.4.0](https://github.com/jolars/badness/compare/badness-parser-v0.3.0...badness-parser-v0.4.0) (2026-08-24)

### Features
- add LSP memory benchmark ([`9a975d7`](https://github.com/jolars/badness/commit/9a975d7dcee69bc143a90ecff041b36d5de356c2))
- **parser:** reparse math fragments ([`4638eb5`](https://github.com/jolars/badness/commit/4638eb5a644019235ef976420e58f47834354fc2))
- add semantic math atom classification ([`3889311`](https://github.com/jolars/badness/commit/388931180fec563d358aef9d2d20f8d6993ddaf1))
- **parser:** add argument domains ([`f7f4b01`](https://github.com/jolars/badness/commit/f7f4b011661f0106028c5e75896096b9b310f4d4))

### Bug Fixes
- **parser:** consume CRLF control symbols atomically ([`20dd182`](https://github.com/jolars/badness/commit/20dd18273e2aec5862abbb5d2d2f945b74467968))
- **parser:** parse alignment char constants ([`78f3cd9`](https://github.com/jolars/badness/commit/78f3cd962b17379141efda3067495df8723f1b67))
- **parser:** guard expl3 mode boundaries ([`08c0387`](https://github.com/jolars/badness/commit/08c0387ec0cad42ad04782d2175f5e61ef294fa3))
- **parser:** unwind environment gate mismatches ([`6398829`](https://github.com/jolars/badness/commit/6398829dde0e22ed7680ca270f846fffd30c5d8d))
- **parser:** gate math environments in groups ([`b221ccd`](https://github.com/jolars/badness/commit/b221ccda0f983ad3ce512d59d8152f63b667a2ad))
- **parser:** tighten catcode signal ([`834c7b6`](https://github.com/jolars/badness/commit/834c7b65b6ab319430e1ed86fdb62582f3b61812))
- **parser:** pass plain braces through optionals ([`82b30f1`](https://github.com/jolars/badness/commit/82b30f17190f935432c3df59fc6428ed33003562))
- **parser:** parse href URLs verbatim ([`03ad84f`](https://github.com/jolars/badness/commit/03ad84f6d78307d155a543b52047e6fc33591d51))
- **parser:** preserve argument mode semantics ([`63aefa8`](https://github.com/jolars/badness/commit/63aefa8e626f9e7e1012ca02ab0370440441c5b2))
- **parser:** honor TeX script atom boundaries ([`e6131b6`](https://github.com/jolars/badness/commit/e6131b69e1df9f3fed25af772fce803655b3e88d))

## [editors/code: 0.18.0](https://github.com/jolars/badness/compare/badness-code-v0.17.0...badness-code-v0.18.0) (2026-08-24)

### Dependencies
- updated badness to v0.18.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).