### PR TITLE
chore(release): v0.19.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "67b39e2968756d1c88c43426db01574334091d70",
+  "baseline-sha": "77833dc6b80ec1e4c9f4c209d735388145ff7a90",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.5.0",
-      "tag": "badness-formatter-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-formatter-v0.6.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.4.0",
-      "tag": "badness-parser-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "badness-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "badness-code-v0.19.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.5.0",
-      "tag": "badness-formatter-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-formatter-v0.6.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.4.0",
-      "tag": "badness-parser-v0.4.0"
+      "version": "0.5.0",
+      "tag": "badness-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "badness-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "badness-code-v0.19.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/badness/compare/v0.18.0...v0.19.0) (2026-08-25)
+
+### Features
+- **linter:** check labels before list items ([`779e9cc`](https://github.com/jolars/badness/commit/779e9cc8492c252968c1dfdecc6a7b927a268b71))
+- **lint:** detect invalid macrocode frames ([`9be2612`](https://github.com/jolars/badness/commit/9be26120c82d3f60c9277781b5e4c17c9bbe23a4))
+- **ci:** scan arXiv source projects ([`c5e256b`](https://github.com/jolars/badness/commit/c5e256bc972ab2e340825eb68eccd20946ee3894)), ref [#152](https://github.com/jolars/badness/issues/152)
+- **formatter:** separate section headings ([`a75a46e`](https://github.com/jolars/badness/commit/a75a46efb9e5affa891f0ca433a44409507b5abf))
+- collect labels from environment options ([`df6f1f3`](https://github.com/jolars/badness/commit/df6f1f3eb336f906c0388794c7863f38a1714304))
+- add command declarations ([`c9effb8`](https://github.com/jolars/badness/commit/c9effb8ffa84d52c3043a4e25d5dfe9921194d64))
+- **lsp:** add table column refactor ([`def2998`](https://github.com/jolars/badness/commit/def299846b63117a15006db3e27a5889dc46afb6))
+- **formatter:** align row terminators ([`7277610`](https://github.com/jolars/badness/commit/7277610c009de809144ae5fdfbd8b542a1e4823b))
+- **lint:** detect extra alignment tabs ([`1129686`](https://github.com/jolars/badness/commit/11296869acb904d5d00457e74421122bd503feb6))
+
+### Bug Fixes
+- **formatter:** keep scripted colon relations tight ([`77833dc`](https://github.com/jolars/badness/commit/77833dc6b80ec1e4c9f4c209d735388145ff7a90))
+- **formatter:** preserve colon relations ([`dbb64a2`](https://github.com/jolars/badness/commit/dbb64a29d381ce16f9ede755cdbb9b3c6a2d8af1))
+- **lsp:** refresh cached config ([`27f22d0`](https://github.com/jolars/badness/commit/27f22d0261fcae03aedbae59b78b5cd4392e2960))
+- **parser:** close citation command set ([`e10aa54`](https://github.com/jolars/badness/commit/e10aa540cc1cb281bba6308e54a4847b6e4045a1))
+- **linter:** handle nested subfigure labels ([`bb0fed5`](https://github.com/jolars/badness/commit/bb0fed5552c64661b0d35b7e96afdf8653dbd66b))
+- **lsp:** scope range formatting to selection ([`4439eeb`](https://github.com/jolars/badness/commit/4439eeb417c72403f8df081256ba20988c81b459)), fixes [#149](https://github.com/jolars/badness/issues/149)
+- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))
+- honor curated ref/cite families in declarations ([`a3aa4ba`](https://github.com/jolars/badness/commit/a3aa4bab04ebd14960ea8cc18efc67d125513b86))
+
+### Performance Improvements
+- firewall declarations by parse and semantic tier ([`ef61239`](https://github.com/jolars/badness/commit/ef61239fa203af274d8de25479dd2fff72a2e49f))
+
+### Dependencies
+- updated crates/badness-formatter to v0.6.0
+- updated crates/badness-parser to v0.5.0
+
 ## [0.18.0](https://github.com/jolars/badness/compare/v0.17.0...v0.18.0) (2026-08-24)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "insta",
  "parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for LaTeX"
@@ -46,8 +46,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.5.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.4.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.6.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.5.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/badness/compare/badness-formatter-v0.5.0...badness-formatter-v0.6.0) (2026-08-25)
+
+### Features
+- **formatter:** separate section headings ([`a75a46e`](https://github.com/jolars/badness/commit/a75a46efb9e5affa891f0ca433a44409507b5abf))
+- **formatter:** align row terminators ([`7277610`](https://github.com/jolars/badness/commit/7277610c009de809144ae5fdfbd8b542a1e4823b))
+- **lint:** detect extra alignment tabs ([`1129686`](https://github.com/jolars/badness/commit/11296869acb904d5d00457e74421122bd503feb6))
+
+### Bug Fixes
+- **formatter:** keep scripted colon relations tight ([`77833dc`](https://github.com/jolars/badness/commit/77833dc6b80ec1e4c9f4c209d735388145ff7a90))
+- **formatter:** preserve colon relations ([`dbb64a2`](https://github.com/jolars/badness/commit/dbb64a29d381ce16f9ede755cdbb9b3c6a2d8af1))
+- **lsp:** scope range formatting to selection ([`4439eeb`](https://github.com/jolars/badness/commit/4439eeb417c72403f8df081256ba20988c81b459)), fixes [#149](https://github.com/jolars/badness/issues/149)
+- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))
+
+### Dependencies
+- updated crates/badness-parser to v0.5.0
+
 ## [0.5.0](https://github.com/jolars/badness/compare/badness-formatter-v0.4.0...badness-formatter-v0.5.0) (2026-08-24)
 
 ### Features

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for LaTeX and BibTeX"
@@ -14,7 +14,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.4.0" }
+badness-parser = { path = "../badness-parser", version = "0.5.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/badness/compare/badness-parser-v0.4.0...badness-parser-v0.5.0) (2026-08-25)
+
+### Features
+- collect labels from environment options ([`df6f1f3`](https://github.com/jolars/badness/commit/df6f1f3eb336f906c0388794c7863f38a1714304))
+- add command declarations ([`c9effb8`](https://github.com/jolars/badness/commit/c9effb8ffa84d52c3043a4e25d5dfe9921194d64))
+
+### Bug Fixes
+- **parser:** close citation command set ([`e10aa54`](https://github.com/jolars/badness/commit/e10aa540cc1cb281bba6308e54a4847b6e4045a1))
+- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))
+- honor curated ref/cite families in declarations ([`a3aa4ba`](https://github.com/jolars/badness/commit/a3aa4bab04ebd14960ea8cc18efc67d125513b86))
+
+### Performance Improvements
+- firewall declarations by parse and semantic tier ([`ef61239`](https://github.com/jolars/badness/commit/ef61239fa203af274d8de25479dd2fff72a2e49f))
+
 ## [0.4.0](https://github.com/jolars/badness/compare/badness-parser-v0.3.0...badness-parser-v0.4.0) (2026-08-24)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, semantic model, and command-signature database for LaTeX and BibTeX"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/badness/compare/badness-code-v0.18.0...badness-code-v0.19.0) (2026-08-25)
+
+### Dependencies
+- updated badness to v0.19.0
+
 ## [0.18.0](https://github.com/jolars/badness/compare/badness-code-v0.17.0...badness-code-v0.18.0) (2026-08-24)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.18.0",
-    "@badness/linux-arm64-gnu": "0.18.0",
-    "@badness/linux-x64-musl": "0.18.0",
-    "@badness/linux-arm64-musl": "0.18.0",
-    "@badness/darwin-x64": "0.18.0",
-    "@badness/darwin-arm64": "0.18.0",
-    "@badness/win32-x64": "0.18.0",
-    "@badness/win32-arm64": "0.18.0"
+    "@badness/linux-x64-gnu": "0.19.0",
+    "@badness/linux-arm64-gnu": "0.19.0",
+    "@badness/linux-x64-musl": "0.19.0",
+    "@badness/linux-arm64-musl": "0.19.0",
+    "@badness/darwin-x64": "0.19.0",
+    "@badness/darwin-arm64": "0.19.0",
+    "@badness/win32-x64": "0.19.0",
+    "@badness/win32-arm64": "0.19.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.19.0](https://github.com/jolars/badness/compare/v0.18.0...v0.19.0) (2026-08-25)

### Features
- **linter:** check labels before list items ([`779e9cc`](https://github.com/jolars/badness/commit/779e9cc8492c252968c1dfdecc6a7b927a268b71))
- **lint:** detect invalid macrocode frames ([`9be2612`](https://github.com/jolars/badness/commit/9be26120c82d3f60c9277781b5e4c17c9bbe23a4))
- **ci:** scan arXiv source projects ([`c5e256b`](https://github.com/jolars/badness/commit/c5e256bc972ab2e340825eb68eccd20946ee3894)), ref [#152](https://github.com/jolars/badness/issues/152)
- **formatter:** separate section headings ([`a75a46e`](https://github.com/jolars/badness/commit/a75a46efb9e5affa891f0ca433a44409507b5abf))
- collect labels from environment options ([`df6f1f3`](https://github.com/jolars/badness/commit/df6f1f3eb336f906c0388794c7863f38a1714304))
- add command declarations ([`c9effb8`](https://github.com/jolars/badness/commit/c9effb8ffa84d52c3043a4e25d5dfe9921194d64))
- **lsp:** add table column refactor ([`def2998`](https://github.com/jolars/badness/commit/def299846b63117a15006db3e27a5889dc46afb6))
- **formatter:** align row terminators ([`7277610`](https://github.com/jolars/badness/commit/7277610c009de809144ae5fdfbd8b542a1e4823b))
- **lint:** detect extra alignment tabs ([`1129686`](https://github.com/jolars/badness/commit/11296869acb904d5d00457e74421122bd503feb6))

### Bug Fixes
- **formatter:** keep scripted colon relations tight ([`77833dc`](https://github.com/jolars/badness/commit/77833dc6b80ec1e4c9f4c209d735388145ff7a90))
- **formatter:** preserve colon relations ([`dbb64a2`](https://github.com/jolars/badness/commit/dbb64a29d381ce16f9ede755cdbb9b3c6a2d8af1))
- **lsp:** refresh cached config ([`27f22d0`](https://github.com/jolars/badness/commit/27f22d0261fcae03aedbae59b78b5cd4392e2960))
- **parser:** close citation command set ([`e10aa54`](https://github.com/jolars/badness/commit/e10aa540cc1cb281bba6308e54a4847b6e4045a1))
- **linter:** handle nested subfigure labels ([`bb0fed5`](https://github.com/jolars/badness/commit/bb0fed5552c64661b0d35b7e96afdf8653dbd66b))
- **lsp:** scope range formatting to selection ([`4439eeb`](https://github.com/jolars/badness/commit/4439eeb417c72403f8df081256ba20988c81b459)), fixes [#149](https://github.com/jolars/badness/issues/149)
- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))
- honor curated ref/cite families in declarations ([`a3aa4ba`](https://github.com/jolars/badness/commit/a3aa4bab04ebd14960ea8cc18efc67d125513b86))

### Performance Improvements
- firewall declarations by parse and semantic tier ([`ef61239`](https://github.com/jolars/badness/commit/ef61239fa203af274d8de25479dd2fff72a2e49f))

### Dependencies
- updated crates/badness-formatter to v0.6.0
- updated crates/badness-parser to v0.5.0

## [crates/badness-formatter: 0.6.0](https://github.com/jolars/badness/compare/badness-formatter-v0.5.0...badness-formatter-v0.6.0) (2026-08-25)

### Features
- **formatter:** separate section headings ([`a75a46e`](https://github.com/jolars/badness/commit/a75a46efb9e5affa891f0ca433a44409507b5abf))
- **formatter:** align row terminators ([`7277610`](https://github.com/jolars/badness/commit/7277610c009de809144ae5fdfbd8b542a1e4823b))
- **lint:** detect extra alignment tabs ([`1129686`](https://github.com/jolars/badness/commit/11296869acb904d5d00457e74421122bd503feb6))

### Bug Fixes
- **formatter:** keep scripted colon relations tight ([`77833dc`](https://github.com/jolars/badness/commit/77833dc6b80ec1e4c9f4c209d735388145ff7a90))
- **formatter:** preserve colon relations ([`dbb64a2`](https://github.com/jolars/badness/commit/dbb64a29d381ce16f9ede755cdbb9b3c6a2d8af1))
- **lsp:** scope range formatting to selection ([`4439eeb`](https://github.com/jolars/badness/commit/4439eeb417c72403f8df081256ba20988c81b459)), fixes [#149](https://github.com/jolars/badness/issues/149)
- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))

### Dependencies
- updated crates/badness-parser to v0.5.0

## [crates/badness-parser: 0.5.0](https://github.com/jolars/badness/compare/badness-parser-v0.4.0...badness-parser-v0.5.0) (2026-08-25)

### Features
- collect labels from environment options ([`df6f1f3`](https://github.com/jolars/badness/commit/df6f1f3eb336f906c0388794c7863f38a1714304))
- add command declarations ([`c9effb8`](https://github.com/jolars/badness/commit/c9effb8ffa84d52c3043a4e25d5dfe9921194d64))

### Bug Fixes
- **parser:** close citation command set ([`e10aa54`](https://github.com/jolars/badness/commit/e10aa540cc1cb281bba6308e54a4847b6e4045a1))
- **formatter:** wrap long citation lists ([`8dbca9e`](https://github.com/jolars/badness/commit/8dbca9e4800b816424eee26c71fa747d475b3c67))
- honor curated ref/cite families in declarations ([`a3aa4ba`](https://github.com/jolars/badness/commit/a3aa4bab04ebd14960ea8cc18efc67d125513b86))

### Performance Improvements
- firewall declarations by parse and semantic tier ([`ef61239`](https://github.com/jolars/badness/commit/ef61239fa203af274d8de25479dd2fff72a2e49f))

## [editors/code: 0.19.0](https://github.com/jolars/badness/compare/badness-code-v0.18.0...badness-code-v0.19.0) (2026-08-25)

### Dependencies
- updated badness to v0.19.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).