### PR TITLE
chore(release): v0.20.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "77833dc6b80ec1e4c9f4c209d735388145ff7a90",
+  "baseline-sha": "5ed601c9fce033e86d3444fd798c86c3c2c74cbd",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.19.0",
-      "tag": "v0.19.0"
+      "version": "0.20.0",
+      "tag": "v0.20.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.6.0",
-      "tag": "badness-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-formatter-v0.7.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.5.0",
-      "tag": "badness-parser-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.19.0",
-      "tag": "badness-code-v0.19.0"
+      "version": "0.20.0",
+      "tag": "badness-code-v0.20.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.19.0",
-      "tag": "v0.19.0"
+      "version": "0.20.0",
+      "tag": "v0.20.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.6.0",
-      "tag": "badness-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-formatter-v0.7.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.5.0",
-      "tag": "badness-parser-v0.5.0"
+      "version": "0.6.0",
+      "tag": "badness-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.19.0",
-      "tag": "badness-code-v0.19.0"
+      "version": "0.20.0",
+      "tag": "badness-code-v0.20.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/badness/compare/v0.19.0...v0.20.0) (2026-08-26)
+
+### Features
+- **formatter:** configure item indentation ([`b869f10`](https://github.com/jolars/badness/commit/b869f10f482a53b0da061db8cf433c818f526889)), closes [#150](https://github.com/jolars/badness/issues/150)
+- **formatter:** indent commented begin arguments ([`1da8350`](https://github.com/jolars/badness/commit/1da83509b392e0ca6df7ddf3a1f33c52851ba0f8))
+- report inert suppression directives ([`70e57f7`](https://github.com/jolars/badness/commit/70e57f7818117d3e7c985dcf468685354a8cbcf2))
+- **lint:** check minipage caption labels ([`6ea84bd`](https://github.com/jolars/badness/commit/6ea84bd9fbdefdbb62363ad28746137d5d81f619))
+- **lint:** flag indented docstrip guards ([`9aabc58`](https://github.com/jolars/badness/commit/9aabc58b05496a3ce8a0277be0646ae6017e6386))
+- drop MSRV to 1.89 ([`b5c6250`](https://github.com/jolars/badness/commit/b5c6250179e1375fb9f408b414276efd06466618))
+- **linter:** warn on retired suppressions ([`7c30f9d`](https://github.com/jolars/badness/commit/7c30f9de47c1374239e46a4fec33f04b21254856))
+
+### Bug Fixes
+- **formatter:** close environment lines ([`c72d71d`](https://github.com/jolars/badness/commit/c72d71d5169f6681388c36fc944f8f306f930891))
+- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
+- **formatter:** align nested math environments ([`eeebbbf`](https://github.com/jolars/badness/commit/eeebbbf640c3d8c78dbfb4e0cd2c422fd7be6855))
+- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))
+
+### Dependencies
+- updated crates/badness-formatter to v0.7.0
+- updated crates/badness-parser to v0.6.0
+
 ## [0.19.0](https://github.com/jolars/badness/compare/v0.18.0...v0.19.0) (2026-08-25)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -48,8 +48,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.6.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.5.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.7.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.6.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/badness/compare/badness-formatter-v0.6.0...badness-formatter-v0.7.0) (2026-08-26)
+
+### Features
+- **formatter:** configure item indentation ([`b869f10`](https://github.com/jolars/badness/commit/b869f10f482a53b0da061db8cf433c818f526889)), closes [#150](https://github.com/jolars/badness/issues/150)
+- **formatter:** indent commented begin arguments ([`1da8350`](https://github.com/jolars/badness/commit/1da83509b392e0ca6df7ddf3a1f33c52851ba0f8))
+
+### Bug Fixes
+- **formatter:** close environment lines ([`c72d71d`](https://github.com/jolars/badness/commit/c72d71d5169f6681388c36fc944f8f306f930891))
+- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
+- **formatter:** preserve math tail context ([`6dcb8ed`](https://github.com/jolars/badness/commit/6dcb8ed58b12f9ce85cedd686614dcc58b348229))
+- **formatter:** align nested math environments ([`eeebbbf`](https://github.com/jolars/badness/commit/eeebbbf640c3d8c78dbfb4e0cd2c422fd7be6855))
+- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))
+
+### Dependencies
+- updated crates/badness-parser to v0.6.0
+
 ## [0.6.0](https://github.com/jolars/badness/compare/badness-formatter-v0.5.0...badness-formatter-v0.6.0) (2026-08-25)
 
 ### Features

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.5.0" }
+badness-parser = { path = "../badness-parser", version = "0.6.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/badness/compare/badness-parser-v0.5.0...badness-parser-v0.6.0) (2026-08-26)
+
+### Features
+- report inert suppression directives ([`70e57f7`](https://github.com/jolars/badness/commit/70e57f7818117d3e7c985dcf468685354a8cbcf2))
+- **lint:** check minipage caption labels ([`6ea84bd`](https://github.com/jolars/badness/commit/6ea84bd9fbdefdbb62363ad28746137d5d81f619))
+- **linter:** warn on retired suppressions ([`7c30f9d`](https://github.com/jolars/badness/commit/7c30f9de47c1374239e46a4fec33f04b21254856))
+
+### Bug Fixes
+- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
+- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))
+
 ## [0.5.0](https://github.com/jolars/badness/compare/badness-parser-v0.4.0...badness-parser-v0.5.0) (2026-08-25)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/badness/compare/badness-code-v0.19.0...badness-code-v0.20.0) (2026-08-26)
+
+### Bug Fixes
+- **editors:** pin `@types/vscode` and update version ([`23c6953`](https://github.com/jolars/badness/commit/23c6953537dca6063e83c2a77d7e2c28588ed73f))
+
+### Dependencies
+- updated badness to v0.20.0
+
 ## [0.19.0](https://github.com/jolars/badness/compare/badness-code-v0.18.0...badness-code-v0.19.0) (2026-08-25)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.19.0",
-    "@badness/linux-arm64-gnu": "0.19.0",
-    "@badness/linux-x64-musl": "0.19.0",
-    "@badness/linux-arm64-musl": "0.19.0",
-    "@badness/darwin-x64": "0.19.0",
-    "@badness/darwin-arm64": "0.19.0",
-    "@badness/win32-x64": "0.19.0",
-    "@badness/win32-arm64": "0.19.0"
+    "@badness/linux-x64-gnu": "0.20.0",
+    "@badness/linux-arm64-gnu": "0.20.0",
+    "@badness/linux-x64-musl": "0.20.0",
+    "@badness/linux-arm64-musl": "0.20.0",
+    "@badness/darwin-x64": "0.20.0",
+    "@badness/darwin-arm64": "0.20.0",
+    "@badness/win32-x64": "0.20.0",
+    "@badness/win32-arm64": "0.20.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.20.0](https://github.com/jolars/badness/compare/v0.19.0...v0.20.0) (2026-08-26)

### Features
- **formatter:** configure item indentation ([`b869f10`](https://github.com/jolars/badness/commit/b869f10f482a53b0da061db8cf433c818f526889)), closes [#150](https://github.com/jolars/badness/issues/150)
- **formatter:** indent commented begin arguments ([`1da8350`](https://github.com/jolars/badness/commit/1da83509b392e0ca6df7ddf3a1f33c52851ba0f8))
- report inert suppression directives ([`70e57f7`](https://github.com/jolars/badness/commit/70e57f7818117d3e7c985dcf468685354a8cbcf2))
- **lint:** check minipage caption labels ([`6ea84bd`](https://github.com/jolars/badness/commit/6ea84bd9fbdefdbb62363ad28746137d5d81f619))
- **lint:** flag indented docstrip guards ([`9aabc58`](https://github.com/jolars/badness/commit/9aabc58b05496a3ce8a0277be0646ae6017e6386))
- drop MSRV to 1.89 ([`b5c6250`](https://github.com/jolars/badness/commit/b5c6250179e1375fb9f408b414276efd06466618))
- **linter:** warn on retired suppressions ([`7c30f9d`](https://github.com/jolars/badness/commit/7c30f9de47c1374239e46a4fec33f04b21254856))

### Bug Fixes
- **formatter:** close environment lines ([`c72d71d`](https://github.com/jolars/badness/commit/c72d71d5169f6681388c36fc944f8f306f930891))
- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
- **formatter:** align nested math environments ([`eeebbbf`](https://github.com/jolars/badness/commit/eeebbbf640c3d8c78dbfb4e0cd2c422fd7be6855))
- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))

### Dependencies
- updated crates/badness-formatter to v0.7.0
- updated crates/badness-parser to v0.6.0

## [crates/badness-formatter: 0.7.0](https://github.com/jolars/badness/compare/badness-formatter-v0.6.0...badness-formatter-v0.7.0) (2026-08-26)

### Features
- **formatter:** configure item indentation ([`b869f10`](https://github.com/jolars/badness/commit/b869f10f482a53b0da061db8cf433c818f526889)), closes [#150](https://github.com/jolars/badness/issues/150)
- **formatter:** indent commented begin arguments ([`1da8350`](https://github.com/jolars/badness/commit/1da83509b392e0ca6df7ddf3a1f33c52851ba0f8))

### Bug Fixes
- **formatter:** close environment lines ([`c72d71d`](https://github.com/jolars/badness/commit/c72d71d5169f6681388c36fc944f8f306f930891))
- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
- **formatter:** preserve math tail context ([`6dcb8ed`](https://github.com/jolars/badness/commit/6dcb8ed58b12f9ce85cedd686614dcc58b348229))
- **formatter:** align nested math environments ([`eeebbbf`](https://github.com/jolars/badness/commit/eeebbbf640c3d8c78dbfb4e0cd2c422fd7be6855))
- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))

### Dependencies
- updated crates/badness-parser to v0.6.0

## [crates/badness-parser: 0.6.0](https://github.com/jolars/badness/compare/badness-parser-v0.5.0...badness-parser-v0.6.0) (2026-08-26)

### Features
- report inert suppression directives ([`70e57f7`](https://github.com/jolars/badness/commit/70e57f7818117d3e7c985dcf468685354a8cbcf2))
- **lint:** check minipage caption labels ([`6ea84bd`](https://github.com/jolars/badness/commit/6ea84bd9fbdefdbb62363ad28746137d5d81f619))
- **linter:** warn on retired suppressions ([`7c30f9d`](https://github.com/jolars/badness/commit/7c30f9de47c1374239e46a4fec33f04b21254856))

### Bug Fixes
- **formatter:** treat gathered as math ([`b31668c`](https://github.com/jolars/badness/commit/b31668c5cd9ce580ccc5d03514c94db62569fcb9))
- support Rust 1.94 ([`a7afd67`](https://github.com/jolars/badness/commit/a7afd671f94f11b0fda1931dc9eef7ba98b67679))

## [editors/code: 0.20.0](https://github.com/jolars/badness/compare/badness-code-v0.19.0...badness-code-v0.20.0) (2026-08-26)

### Bug Fixes
- **editors:** pin `@types/vscode` and update version ([`23c6953`](https://github.com/jolars/badness/commit/23c6953537dca6063e83c2a77d7e2c28588ed73f))

### Dependencies
- updated badness to v0.20.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).