### PR TITLE
chore(release): v0.21.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5ed601c9fce033e86d3444fd798c86c3c2c74cbd",
+  "baseline-sha": "e0567a9b2034a68737d0cb5b54f25a1c581bf8cc",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.20.0",
-      "tag": "v0.20.0"
+      "version": "0.21.0",
+      "tag": "v0.21.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.7.0",
-      "tag": "badness-formatter-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-formatter-v0.8.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.6.0",
-      "tag": "badness-parser-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-parser-v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.20.0",
-      "tag": "badness-code-v0.20.0"
+      "version": "0.21.0",
+      "tag": "badness-code-v0.21.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.20.0",
-      "tag": "v0.20.0"
+      "version": "0.21.0",
+      "tag": "v0.21.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.7.0",
-      "tag": "badness-formatter-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-formatter-v0.8.0"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.6.0",
-      "tag": "badness-parser-v0.6.0"
+      "version": "0.7.0",
+      "tag": "badness-parser-v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.20.0",
-      "tag": "badness-code-v0.20.0"
+      "version": "0.21.0",
+      "tag": "badness-code-v0.21.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.21.0](https://github.com/jolars/badness/compare/v0.20.0...v0.21.0) (2026-08-27)
+
+### Features
+- **formatter:** close display math lines ([`7394f25`](https://github.com/jolars/badness/commit/7394f2547d34c22f1d005c7832273200ddae4d80))
+- **formatter:** glue inline command arguments ([`f1093ff`](https://github.com/jolars/badness/commit/f1093ff47df04a3921f3608408e8f4b74de14a2d))
+- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))
+- **editors:** add Zed extension ([`c898e44`](https://github.com/jolars/badness/commit/c898e442f2aff047761d55f39dd7b2480a707c09))
+
+### Bug Fixes
+- **formatter:** preserve BibTeX lint directives ([`e0567a9`](https://github.com/jolars/badness/commit/e0567a9b2034a68737d0cb5b54f25a1c581bf8cc)), fixes [#159](https://github.com/jolars/badness/issues/159)
+- **formatter:** split commented begin tails ([`5d30318`](https://github.com/jolars/badness/commit/5d303186c912fb778ac09c7bbf56c612f50d508f))
+- **formatter:** preserve authored line-break rows ([`4886414`](https://github.com/jolars/badness/commit/488641446488f0b9360e16890cec8ab5367c606f))
+- **lint:** remove `\paragraph` rule from headings lint ([`0343e90`](https://github.com/jolars/badness/commit/0343e90ade08f1ee89477611a2a51b6cabddc5c7))
+- **lint:** retire mismatched delimiter rule ([`a034f0b`](https://github.com/jolars/badness/commit/a034f0bd20106f11286e7b1c189f58ac64b83f3a))
+- **formatter:** keep labels with headings ([`7ba5fa5`](https://github.com/jolars/badness/commit/7ba5fa57be034a78598c248dbfa630b8c3852046))
+- **formatter:** match omitted environment slots ([`c00340f`](https://github.com/jolars/badness/commit/c00340f45f3b0c55bf48becc2365e77cf2ea464f))
+- **formatter:** honor control-word boundaries ([`4ee6fc6`](https://github.com/jolars/badness/commit/4ee6fc6d89bf1314f8a319fd8805835fd37a92c5))
+- **formatter:** recognize unary math signs ([`6afa14f`](https://github.com/jolars/badness/commit/6afa14fa237327e9de92fbc0cbf1be3e4d8c6acc))
+
+### Performance Improvements
+- **formatter:** cache group break state ([`4a37963`](https://github.com/jolars/badness/commit/4a37963a7fefc8027997757ab4d7d24d150bf509))
+
+### Dependencies
+- updated crates/badness-formatter to v0.8.0
+- updated crates/badness-parser to v0.7.0
+
 ## [0.20.0](https://github.com/jolars/badness/compare/v0.19.0...v0.20.0) (2026-08-26)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "parser",
@@ -194,9 +194,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -634,9 +634,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -48,8 +48,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.7.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.6.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.8.0" }
+badness-parser = { path = "crates/badness-parser", version = "0.7.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/badness/compare/badness-formatter-v0.7.0...badness-formatter-v0.8.0) (2026-08-27)
+
+### Features
+- **formatter:** close display math lines ([`7394f25`](https://github.com/jolars/badness/commit/7394f2547d34c22f1d005c7832273200ddae4d80))
+- **formatter:** glue inline command arguments ([`f1093ff`](https://github.com/jolars/badness/commit/f1093ff47df04a3921f3608408e8f4b74de14a2d))
+- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))
+
+### Bug Fixes
+- **formatter:** preserve BibTeX lint directives ([`e0567a9`](https://github.com/jolars/badness/commit/e0567a9b2034a68737d0cb5b54f25a1c581bf8cc)), fixes [#159](https://github.com/jolars/badness/issues/159)
+- **formatter:** align commented statements ([`440eca0`](https://github.com/jolars/badness/commit/440eca0d1f8f9ebe955e70a0e3d56e9be99b9b01)), fixes [#158](https://github.com/jolars/badness/issues/158)
+- **formatter:** split commented begin tails ([`5d30318`](https://github.com/jolars/badness/commit/5d303186c912fb778ac09c7bbf56c612f50d508f))
+- **formatter:** tighten keyval commas ([`d9a3453`](https://github.com/jolars/badness/commit/d9a3453f54dfaa3e8ef943a6ea8a7b25d469bec5))
+- **formatter:** preserve authored line-break rows ([`4886414`](https://github.com/jolars/badness/commit/488641446488f0b9360e16890cec8ab5367c606f))
+- **formatter:** keep labels with headings ([`7ba5fa5`](https://github.com/jolars/badness/commit/7ba5fa57be034a78598c248dbfa630b8c3852046))
+- **formatter:** match omitted environment slots ([`c00340f`](https://github.com/jolars/badness/commit/c00340f45f3b0c55bf48becc2365e77cf2ea464f))
+- **formatter:** honor control-word boundaries ([`4ee6fc6`](https://github.com/jolars/badness/commit/4ee6fc6d89bf1314f8a319fd8805835fd37a92c5))
+- **formatter:** recognize unary math signs ([`6afa14f`](https://github.com/jolars/badness/commit/6afa14fa237327e9de92fbc0cbf1be3e4d8c6acc))
+
+### Performance Improvements
+- **formatter:** cache group break state ([`4a37963`](https://github.com/jolars/badness/commit/4a37963a7fefc8027997757ab4d7d24d150bf509))
+
+### Dependencies
+- updated crates/badness-parser to v0.7.0
+
 ## [0.7.0](https://github.com/jolars/badness/compare/badness-formatter-v0.6.0...badness-formatter-v0.7.0) (2026-08-26)
 
 ### Features

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.6.0" }
+badness-parser = { path = "../badness-parser", version = "0.7.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/badness/compare/badness-parser-v0.6.0...badness-parser-v0.7.0) (2026-08-27)
+
+### Features
+- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))
+
 ## [0.6.0](https://github.com/jolars/badness/compare/badness-parser-v0.5.0...badness-parser-v0.6.0) (2026-08-26)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.21.0](https://github.com/jolars/badness/compare/badness-code-v0.20.0...badness-code-v0.21.0) (2026-08-27)
+
+### Dependencies
+- updated badness to v0.21.0
+
 ## [0.20.0](https://github.com/jolars/badness/compare/badness-code-v0.19.0...badness-code-v0.20.0) (2026-08-26)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         badness = pkgs.rustPlatform.buildRustPackage {
           pname = "badness";
-          version = "0.20.0";
+          version = "0.21.0";
 
           src = ./.;
 

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.20.0",
-    "@badness/linux-arm64-gnu": "0.20.0",
-    "@badness/linux-x64-musl": "0.20.0",
-    "@badness/linux-arm64-musl": "0.20.0",
-    "@badness/darwin-x64": "0.20.0",
-    "@badness/darwin-arm64": "0.20.0",
-    "@badness/win32-x64": "0.20.0",
-    "@badness/win32-arm64": "0.20.0"
+    "@badness/linux-x64-gnu": "0.21.0",
+    "@badness/linux-arm64-gnu": "0.21.0",
+    "@badness/linux-x64-musl": "0.21.0",
+    "@badness/linux-arm64-musl": "0.21.0",
+    "@badness/darwin-x64": "0.21.0",
+    "@badness/darwin-arm64": "0.21.0",
+    "@badness/win32-x64": "0.21.0",
+    "@badness/win32-arm64": "0.21.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.21.0](https://github.com/jolars/badness/compare/v0.20.0...v0.21.0) (2026-08-27)

### Features
- **formatter:** close display math lines ([`7394f25`](https://github.com/jolars/badness/commit/7394f2547d34c22f1d005c7832273200ddae4d80))
- **formatter:** glue inline command arguments ([`f1093ff`](https://github.com/jolars/badness/commit/f1093ff47df04a3921f3608408e8f4b74de14a2d))
- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))
- **editors:** add Zed extension ([`c898e44`](https://github.com/jolars/badness/commit/c898e442f2aff047761d55f39dd7b2480a707c09))

### Bug Fixes
- **formatter:** preserve BibTeX lint directives ([`e0567a9`](https://github.com/jolars/badness/commit/e0567a9b2034a68737d0cb5b54f25a1c581bf8cc)), fixes [#159](https://github.com/jolars/badness/issues/159)
- **formatter:** split commented begin tails ([`5d30318`](https://github.com/jolars/badness/commit/5d303186c912fb778ac09c7bbf56c612f50d508f))
- **formatter:** preserve authored line-break rows ([`4886414`](https://github.com/jolars/badness/commit/488641446488f0b9360e16890cec8ab5367c606f))
- **lint:** remove `\paragraph` rule from headings lint ([`0343e90`](https://github.com/jolars/badness/commit/0343e90ade08f1ee89477611a2a51b6cabddc5c7))
- **lint:** retire mismatched delimiter rule ([`a034f0b`](https://github.com/jolars/badness/commit/a034f0bd20106f11286e7b1c189f58ac64b83f3a))
- **formatter:** keep labels with headings ([`7ba5fa5`](https://github.com/jolars/badness/commit/7ba5fa57be034a78598c248dbfa630b8c3852046))
- **formatter:** match omitted environment slots ([`c00340f`](https://github.com/jolars/badness/commit/c00340f45f3b0c55bf48becc2365e77cf2ea464f))
- **formatter:** honor control-word boundaries ([`4ee6fc6`](https://github.com/jolars/badness/commit/4ee6fc6d89bf1314f8a319fd8805835fd37a92c5))
- **formatter:** recognize unary math signs ([`6afa14f`](https://github.com/jolars/badness/commit/6afa14fa237327e9de92fbc0cbf1be3e4d8c6acc))

### Performance Improvements
- **formatter:** cache group break state ([`4a37963`](https://github.com/jolars/badness/commit/4a37963a7fefc8027997757ab4d7d24d150bf509))

### Dependencies
- updated crates/badness-formatter to v0.8.0
- updated crates/badness-parser to v0.7.0

## [crates/badness-formatter: 0.8.0](https://github.com/jolars/badness/compare/badness-formatter-v0.7.0...badness-formatter-v0.8.0) (2026-08-27)

### Features
- **formatter:** close display math lines ([`7394f25`](https://github.com/jolars/badness/commit/7394f2547d34c22f1d005c7832273200ddae4d80))
- **formatter:** glue inline command arguments ([`f1093ff`](https://github.com/jolars/badness/commit/f1093ff47df04a3921f3608408e8f4b74de14a2d))
- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))

### Bug Fixes
- **formatter:** preserve BibTeX lint directives ([`e0567a9`](https://github.com/jolars/badness/commit/e0567a9b2034a68737d0cb5b54f25a1c581bf8cc)), fixes [#159](https://github.com/jolars/badness/issues/159)
- **formatter:** align commented statements ([`440eca0`](https://github.com/jolars/badness/commit/440eca0d1f8f9ebe955e70a0e3d56e9be99b9b01)), fixes [#158](https://github.com/jolars/badness/issues/158)
- **formatter:** split commented begin tails ([`5d30318`](https://github.com/jolars/badness/commit/5d303186c912fb778ac09c7bbf56c612f50d508f))
- **formatter:** tighten keyval commas ([`d9a3453`](https://github.com/jolars/badness/commit/d9a3453f54dfaa3e8ef943a6ea8a7b25d469bec5))
- **formatter:** preserve authored line-break rows ([`4886414`](https://github.com/jolars/badness/commit/488641446488f0b9360e16890cec8ab5367c606f))
- **formatter:** keep labels with headings ([`7ba5fa5`](https://github.com/jolars/badness/commit/7ba5fa57be034a78598c248dbfa630b8c3852046))
- **formatter:** match omitted environment slots ([`c00340f`](https://github.com/jolars/badness/commit/c00340f45f3b0c55bf48becc2365e77cf2ea464f))
- **formatter:** honor control-word boundaries ([`4ee6fc6`](https://github.com/jolars/badness/commit/4ee6fc6d89bf1314f8a319fd8805835fd37a92c5))
- **formatter:** recognize unary math signs ([`6afa14f`](https://github.com/jolars/badness/commit/6afa14fa237327e9de92fbc0cbf1be3e4d8c6acc))

### Performance Improvements
- **formatter:** cache group break state ([`4a37963`](https://github.com/jolars/badness/commit/4a37963a7fefc8027997757ab4d7d24d150bf509))

### Dependencies
- updated crates/badness-parser to v0.7.0

## [crates/badness-parser: 0.7.0](https://github.com/jolars/badness/compare/badness-parser-v0.6.0...badness-parser-v0.7.0) (2026-08-27)

### Features
- **formatter:** split environment keyvals ([`3ea1412`](https://github.com/jolars/badness/commit/3ea14126ad154a33deab073d1142524370a29174))

## [editors/code: 0.21.0](https://github.com/jolars/badness/compare/badness-code-v0.20.0...badness-code-v0.21.0) (2026-08-27)

### Dependencies
- updated badness to v0.21.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).