### PR TITLE
chore(release): v0.22.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "e0567a9b2034a68737d0cb5b54f25a1c581bf8cc",
+  "baseline-sha": "11f2a76ac0f8980aa721bfb544028a4265354cc0",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.21.0",
-      "tag": "v0.21.0"
+      "version": "0.22.0",
+      "tag": "v0.22.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.0",
-      "tag": "badness-formatter-v0.8.0"
+      "version": "0.8.1",
+      "tag": "badness-formatter-v0.8.1"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.7.0",
-      "tag": "badness-parser-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-parser-v0.8.0"
     },
     {
       "path": "editors/code",
-      "version": "0.21.0",
-      "tag": "badness-code-v0.21.0"
+      "version": "0.22.0",
+      "tag": "badness-code-v0.22.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.21.0",
-      "tag": "v0.21.0"
+      "version": "0.22.0",
+      "tag": "v0.22.0"
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.0",
-      "tag": "badness-formatter-v0.8.0"
+      "version": "0.8.1",
+      "tag": "badness-formatter-v0.8.1"
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.7.0",
-      "tag": "badness-parser-v0.7.0"
+      "version": "0.8.0",
+      "tag": "badness-parser-v0.8.0"
     },
     {
       "path": "editors/code",
-      "version": "0.21.0",
-      "tag": "badness-code-v0.21.0"
+      "version": "0.22.0",
+      "tag": "badness-code-v0.22.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/badness/compare/v0.21.0...v0.22.0) (2026-08-28)
+
+### Features
+- **lsp:** add Beamer frame symbols ([`11f2a76`](https://github.com/jolars/badness/commit/11f2a76ac0f8980aa721bfb544028a4265354cc0))
+
+### Bug Fixes
+- accept Windows short paths in BIBINPUTS ([`3a243cd`](https://github.com/jolars/badness/commit/3a243cd553f69f0bee1517160d51dfb15f574352))
+- resolve bibliography search paths ([`c867a8e`](https://github.com/jolars/badness/commit/c867a8e5b30d704fc269cdbd110bccdaf506ff5d)), fixes [#161](https://github.com/jolars/badness/issues/161)
+- **formatter:** align macro statement prefixes ([`4e7efa5`](https://github.com/jolars/badness/commit/4e7efa558386c94be8ba5da640b01a1d8dd35866)), fixes [#158](https://github.com/jolars/badness/issues/158)
+- **formatter:** prioritize math breakpoints ([`9f85294`](https://github.com/jolars/badness/commit/9f852940dc914f6a589c1dd484cc78ba3fe0f47c))
+- **formatter:** preserve postfix limit signs ([`658ef51`](https://github.com/jolars/badness/commit/658ef51b417d6af26e78d0ec839b050186998bfc))
+- loosen test ([`5a6eeb8`](https://github.com/jolars/badness/commit/5a6eeb8a1d302c6940fbcb4e5b6e7f8c564b8e55))
+
+### Dependencies
+- updated crates/badness-formatter to v0.8.1
+- updated crates/badness-parser to v0.8.0
+
 ## [0.21.0](https://github.com/jolars/badness/compare/v0.20.0...v0.21.0) (2026-08-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "parser",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -48,8 +48,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.8.0" }
-badness-parser = { path = "crates/badness-parser", version = "0.7.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.8.1" }
+badness-parser = { path = "crates/badness-parser", version = "0.8.0" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.1](https://github.com/jolars/badness/compare/badness-formatter-v0.8.0...badness-formatter-v0.8.1) (2026-08-28)
+
+### Bug Fixes
+- **formatter:** drop root block indentation ([`aad72e8`](https://github.com/jolars/badness/commit/aad72e87c593241beef4169ea9e06fc543815df1)), fixes [#162](https://github.com/jolars/badness/issues/162)
+- **formatter:** align macro statement prefixes ([`4e7efa5`](https://github.com/jolars/badness/commit/4e7efa558386c94be8ba5da640b01a1d8dd35866)), fixes [#158](https://github.com/jolars/badness/issues/158)
+- **formatter:** prioritize math breakpoints ([`9f85294`](https://github.com/jolars/badness/commit/9f852940dc914f6a589c1dd484cc78ba3fe0f47c))
+- **formatter:** preserve postfix limit signs ([`658ef51`](https://github.com/jolars/badness/commit/658ef51b417d6af26e78d0ec839b050186998bfc))
+
+### Dependencies
+- updated crates/badness-parser to v0.8.0
+
 ## [0.8.0](https://github.com/jolars/badness/compare/badness-formatter-v0.7.0...badness-formatter-v0.8.0) (2026-08-27)
 
 ### Features

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.7.0" }
+badness-parser = { path = "../badness-parser", version = "0.8.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/badness/compare/badness-parser-v0.7.0...badness-parser-v0.8.0) (2026-08-28)
+
+### Features
+- **lsp:** add Beamer frame symbols ([`11f2a76`](https://github.com/jolars/badness/commit/11f2a76ac0f8980aa721bfb544028a4265354cc0))
+
 ## [0.7.0](https://github.com/jolars/badness/compare/badness-parser-v0.6.0...badness-parser-v0.7.0) (2026-08-27)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/badness/compare/badness-code-v0.21.0...badness-code-v0.22.0) (2026-08-28)
+
+### Dependencies
+- updated badness to v0.22.0
+
 ## [0.21.0](https://github.com/jolars/badness/compare/badness-code-v0.20.0...badness-code-v0.21.0) (2026-08-27)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -66,12 +66,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -310,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -352,9 +353,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -821,6 +822,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         badness = pkgs.rustPlatform.buildRustPackage {
           pname = "badness";
-          version = "0.21.0";
+          version = "0.22.0";
 
           src = ./.;
 

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.21.0",
-    "@badness/linux-arm64-gnu": "0.21.0",
-    "@badness/linux-x64-musl": "0.21.0",
-    "@badness/linux-arm64-musl": "0.21.0",
-    "@badness/darwin-x64": "0.21.0",
-    "@badness/darwin-arm64": "0.21.0",
-    "@badness/win32-x64": "0.21.0",
-    "@badness/win32-arm64": "0.21.0"
+    "@badness/linux-x64-gnu": "0.22.0",
+    "@badness/linux-arm64-gnu": "0.22.0",
+    "@badness/linux-x64-musl": "0.22.0",
+    "@badness/linux-arm64-musl": "0.22.0",
+    "@badness/darwin-x64": "0.22.0",
+    "@badness/darwin-arm64": "0.22.0",
+    "@badness/win32-x64": "0.22.0",
+    "@badness/win32-arm64": "0.22.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.22.0](https://github.com/jolars/badness/compare/v0.21.0...v0.22.0) (2026-08-28)

### Features
- **lsp:** add Beamer frame symbols ([`11f2a76`](https://github.com/jolars/badness/commit/11f2a76ac0f8980aa721bfb544028a4265354cc0))

### Bug Fixes
- accept Windows short paths in BIBINPUTS ([`3a243cd`](https://github.com/jolars/badness/commit/3a243cd553f69f0bee1517160d51dfb15f574352))
- resolve bibliography search paths ([`c867a8e`](https://github.com/jolars/badness/commit/c867a8e5b30d704fc269cdbd110bccdaf506ff5d)), fixes [#161](https://github.com/jolars/badness/issues/161)
- **formatter:** align macro statement prefixes ([`4e7efa5`](https://github.com/jolars/badness/commit/4e7efa558386c94be8ba5da640b01a1d8dd35866)), fixes [#158](https://github.com/jolars/badness/issues/158)
- **formatter:** prioritize math breakpoints ([`9f85294`](https://github.com/jolars/badness/commit/9f852940dc914f6a589c1dd484cc78ba3fe0f47c))
- **formatter:** preserve postfix limit signs ([`658ef51`](https://github.com/jolars/badness/commit/658ef51b417d6af26e78d0ec839b050186998bfc))
- loosen test ([`5a6eeb8`](https://github.com/jolars/badness/commit/5a6eeb8a1d302c6940fbcb4e5b6e7f8c564b8e55))

### Dependencies
- updated crates/badness-formatter to v0.8.1
- updated crates/badness-parser to v0.8.0

## [crates/badness-formatter: 0.8.1](https://github.com/jolars/badness/compare/badness-formatter-v0.8.0...badness-formatter-v0.8.1) (2026-08-28)

### Bug Fixes
- **formatter:** drop root block indentation ([`aad72e8`](https://github.com/jolars/badness/commit/aad72e87c593241beef4169ea9e06fc543815df1)), fixes [#162](https://github.com/jolars/badness/issues/162)
- **formatter:** align macro statement prefixes ([`4e7efa5`](https://github.com/jolars/badness/commit/4e7efa558386c94be8ba5da640b01a1d8dd35866)), fixes [#158](https://github.com/jolars/badness/issues/158)
- **formatter:** prioritize math breakpoints ([`9f85294`](https://github.com/jolars/badness/commit/9f852940dc914f6a589c1dd484cc78ba3fe0f47c))
- **formatter:** preserve postfix limit signs ([`658ef51`](https://github.com/jolars/badness/commit/658ef51b417d6af26e78d0ec839b050186998bfc))

### Dependencies
- updated crates/badness-parser to v0.8.0

## [crates/badness-parser: 0.8.0](https://github.com/jolars/badness/compare/badness-parser-v0.7.0...badness-parser-v0.8.0) (2026-08-28)

### Features
- **lsp:** add Beamer frame symbols ([`11f2a76`](https://github.com/jolars/badness/commit/11f2a76ac0f8980aa721bfb544028a4265354cc0))

## [editors/code: 0.22.0](https://github.com/jolars/badness/compare/badness-code-v0.21.0...badness-code-v0.22.0) (2026-08-28)

### Dependencies
- updated badness to v0.22.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).