### PR TITLE
chore(release): v0.22.1 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,68 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "11f2a76ac0f8980aa721bfb544028a4265354cc0",
+  "baseline-sha": "04d20736e8515e6cf17249e821eb8875cc64a548",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.22.0",
-      "tag": "v0.22.0"
+      "version": "0.22.1",
+      "tag": "v0.22.1",
+      "dependencies": [
+        "crates/badness-formatter",
+        "crates/badness-parser"
+      ]
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.1",
-      "tag": "badness-formatter-v0.8.1"
+      "version": "0.8.2",
+      "tag": "badness-formatter-v0.8.2",
+      "dependencies": [
+        "crates/badness-parser"
+      ]
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.8.0",
-      "tag": "badness-parser-v0.8.0"
+      "version": "0.8.1",
+      "tag": "badness-parser-v0.8.1"
     },
     {
       "path": "editors/code",
-      "version": "0.22.0",
-      "tag": "badness-code-v0.22.0"
+      "version": "0.22.1",
+      "tag": "badness-code-v0.22.1",
+      "dependencies": [
+        "."
+      ]
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.22.0",
-      "tag": "v0.22.0"
+      "version": "0.22.1",
+      "tag": "v0.22.1",
+      "dependencies": [
+        "crates/badness-formatter",
+        "crates/badness-parser"
+      ]
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.1",
-      "tag": "badness-formatter-v0.8.1"
+      "version": "0.8.2",
+      "tag": "badness-formatter-v0.8.2",
+      "dependencies": [
+        "crates/badness-parser"
+      ]
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.8.0",
-      "tag": "badness-parser-v0.8.0"
+      "version": "0.8.1",
+      "tag": "badness-parser-v0.8.1"
     },
     {
       "path": "editors/code",
-      "version": "0.22.0",
-      "tag": "badness-code-v0.22.0"
+      "version": "0.22.1",
+      "tag": "badness-code-v0.22.1",
+      "dependencies": [
+        "."
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.22.1](https://github.com/jolars/badness/compare/v0.22.0...v0.22.1) (2026-08-31)
+
+### Bug Fixes
+- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)
+- **formatter:** normalize commented env args ([`6154eb9`](https://github.com/jolars/badness/commit/6154eb9a0bbf7e8d961ca66bc7863b9e1779654f))
+
+### Dependencies
+- updated crates/badness-formatter to v0.8.2
+- updated crates/badness-parser to v0.8.1
+
 ## [0.22.0](https://github.com/jolars/badness/compare/v0.21.0...v0.22.0) (2026-08-28)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "badness-parser",
  "insta",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "insta",
  "parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -48,8 +48,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.8.1" }
-badness-parser = { path = "crates/badness-parser", version = "0.8.0" }
+badness-formatter = { path = "crates/badness-formatter", version = "0.8.2" }
+badness-parser = { path = "crates/badness-parser", version = "0.8.1" }
 clap = { version = "4.5.51", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.2](https://github.com/jolars/badness/compare/badness-formatter-v0.8.1...badness-formatter-v0.8.2) (2026-08-31)
+
+### Bug Fixes
+- **formatter:** keep dtx labels with headings ([`04d2073`](https://github.com/jolars/badness/commit/04d20736e8515e6cf17249e821eb8875cc64a548)), fixes [#166](https://github.com/jolars/badness/issues/166)
+- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)
+- **formatter:** indent environment header arguments ([`1431943`](https://github.com/jolars/badness/commit/14319433e12932a40fba8eb93b1813cd9de2ff97))
+- **formatter:** normalize commented env args ([`6154eb9`](https://github.com/jolars/badness/commit/6154eb9a0bbf7e8d961ca66bc7863b9e1779654f))
+
+### Dependencies
+- updated crates/badness-parser to v0.8.1
+
 ## [0.8.1](https://github.com/jolars/badness/compare/badness-formatter-v0.8.0...badness-formatter-v0.8.1) (2026-08-28)
 
 ### Bug Fixes

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.8.0" }
+badness-parser = { path = "../badness-parser", version = "0.8.1" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.1](https://github.com/jolars/badness/compare/badness-parser-v0.8.0...badness-parser-v0.8.1) (2026-08-31)
+
+### Bug Fixes
+- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)
+
 ## [0.8.0](https://github.com/jolars/badness/compare/badness-parser-v0.7.0...badness-parser-v0.8.0) (2026-08-28)
 
 ### Features

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.22.1](https://github.com/jolars/badness/compare/badness-code-v0.22.0...badness-code-v0.22.1) (2026-08-31)
+
+### Dependencies
+- updated badness to v0.22.1
+
 ## [0.22.0](https://github.com/jolars/badness/compare/badness-code-v0.21.0...badness-code-v0.22.0) (2026-08-28)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         badness = pkgs.rustPlatform.buildRustPackage {
           pname = "badness";
-          version = "0.22.0";
+          version = "0.22.1";
 
           src = ./.;
 

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.22.0",
-    "@badness/linux-arm64-gnu": "0.22.0",
-    "@badness/linux-x64-musl": "0.22.0",
-    "@badness/linux-arm64-musl": "0.22.0",
-    "@badness/darwin-x64": "0.22.0",
-    "@badness/darwin-arm64": "0.22.0",
-    "@badness/win32-x64": "0.22.0",
-    "@badness/win32-arm64": "0.22.0"
+    "@badness/linux-x64-gnu": "0.22.1",
+    "@badness/linux-arm64-gnu": "0.22.1",
+    "@badness/linux-x64-musl": "0.22.1",
+    "@badness/linux-arm64-musl": "0.22.1",
+    "@badness/darwin-x64": "0.22.1",
+    "@badness/darwin-arm64": "0.22.1",
+    "@badness/win32-x64": "0.22.1",
+    "@badness/win32-arm64": "0.22.1"
   }
 }


### PR DESCRIPTION
## [badness: 0.22.1](https://github.com/jolars/badness/compare/v0.22.0...v0.22.1) (2026-08-31)

### Bug Fixes
- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)
- **formatter:** normalize commented env args ([`6154eb9`](https://github.com/jolars/badness/commit/6154eb9a0bbf7e8d961ca66bc7863b9e1779654f))

### Dependencies
- updated crates/badness-formatter to v0.8.2
- updated crates/badness-parser to v0.8.1

## [crates/badness-formatter: 0.8.2](https://github.com/jolars/badness/compare/badness-formatter-v0.8.1...badness-formatter-v0.8.2) (2026-08-31)

### Bug Fixes
- **formatter:** keep dtx labels with headings ([`04d2073`](https://github.com/jolars/badness/commit/04d20736e8515e6cf17249e821eb8875cc64a548)), fixes [#166](https://github.com/jolars/badness/issues/166)
- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)
- **formatter:** indent environment header arguments ([`1431943`](https://github.com/jolars/badness/commit/14319433e12932a40fba8eb93b1813cd9de2ff97))
- **formatter:** normalize commented env args ([`6154eb9`](https://github.com/jolars/badness/commit/6154eb9a0bbf7e8d961ca66bc7863b9e1779654f))

### Dependencies
- updated crates/badness-parser to v0.8.1

## [crates/badness-parser: 0.8.1](https://github.com/jolars/badness/compare/badness-parser-v0.8.0...badness-parser-v0.8.1) (2026-08-31)

### Bug Fixes
- **formatter:** attach citations to sentences ([`57e9bb8`](https://github.com/jolars/badness/commit/57e9bb8c25ff4315de9f4d978c930c7b41c21c15)), fixes [#163](https://github.com/jolars/badness/issues/163)

## [editors/code: 0.22.1](https://github.com/jolars/badness/compare/badness-code-v0.22.0...badness-code-v0.22.1) (2026-08-31)

### Dependencies
- updated badness to v0.22.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).