### PR TITLE
chore(release): v0.23.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "04d20736e8515e6cf17249e821eb8875cc64a548",
+  "baseline-sha": "08b52434f0d163ffbf04f6a80bc235fde17f6ec6",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.22.1",
-      "tag": "v0.22.1",
+      "version": "0.23.0",
+      "tag": "v0.23.0",
       "dependencies": [
         "crates/badness-formatter",
         "crates/badness-parser"
@@ -13,21 +13,21 @@
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.2",
-      "tag": "badness-formatter-v0.8.2",
+      "version": "0.8.3",
+      "tag": "badness-formatter-v0.8.3",
       "dependencies": [
         "crates/badness-parser"
       ]
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.8.1",
-      "tag": "badness-parser-v0.8.1"
+      "version": "0.9.0",
+      "tag": "badness-parser-v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.22.1",
-      "tag": "badness-code-v0.22.1",
+      "version": "0.23.0",
+      "tag": "badness-code-v0.23.0",
       "dependencies": [
         "."
       ]
@@ -36,8 +36,8 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.22.1",
-      "tag": "v0.22.1",
+      "version": "0.23.0",
+      "tag": "v0.23.0",
       "dependencies": [
         "crates/badness-formatter",
         "crates/badness-parser"
@@ -45,21 +45,21 @@
     },
     {
       "path": "crates/badness-formatter",
-      "version": "0.8.2",
-      "tag": "badness-formatter-v0.8.2",
+      "version": "0.8.3",
+      "tag": "badness-formatter-v0.8.3",
       "dependencies": [
         "crates/badness-parser"
       ]
     },
     {
       "path": "crates/badness-parser",
-      "version": "0.8.1",
-      "tag": "badness-parser-v0.8.1"
+      "version": "0.9.0",
+      "tag": "badness-parser-v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.22.1",
-      "tag": "badness-code-v0.22.1",
+      "version": "0.23.0",
+      "tag": "badness-code-v0.23.0",
       "dependencies": [
         "."
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/badness/compare/v0.22.1...v0.23.0) (2026-09-03)
+
+### Features
+- **config:** publish JSON schema ([`f83cacd`](https://github.com/jolars/badness/commit/f83cacd8c526d31c4f321e818e18fbd838e4a02d))
+- **lint:** support opt-in rules ([`8cc742a`](https://github.com/jolars/badness/commit/8cc742ac68a9cda8d520ced7e5f395b1700a2978))
+
+### Bug Fixes
+- **linter:** skip positional verbatim arguments ([`08b5243`](https://github.com/jolars/badness/commit/08b52434f0d163ffbf04f6a80bc235fde17f6ec6)), fixes [#175](https://github.com/jolars/badness/issues/175)
+- **linter:** ignore Beamer overlay ranges ([`d57390f`](https://github.com/jolars/badness/commit/d57390f2990f14f0859cf59431c82dd32aa872de)), fixes [#174](https://github.com/jolars/badness/issues/174)
+- **formatter:** stabilize long optionals ([`04d8ecf`](https://github.com/jolars/badness/commit/04d8ecfc280b9071b759724dcfa7347b75b20219))
+- **parser:** parse long mixed optionals ([`38adc16`](https://github.com/jolars/badness/commit/38adc16dd07b4b6d85820f31dd63dd86eed6a567))
+- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)
+- **linter:** retain braces around math operators ([`946bf2b`](https://github.com/jolars/badness/commit/946bf2bad4f091477e14d1f321c0e2cdd2781276))
+
+### Dependencies
+- updated crates/badness-formatter to v0.8.3
+- updated crates/badness-parser to v0.9.0
+
 ## [0.22.1](https://github.com/jolars/badness/compare/v0.22.0...v0.22.1) (2026-08-31)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "badness"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "annotate-snippets",
  "badness-formatter",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "badness-formatter"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "badness-parser",
  "insta",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "badness-parser"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "insta",
  "parser",
@@ -891,9 +891,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -1728,9 +1728,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smol_str"
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "badness"
-version = "0.22.1"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -48,8 +48,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-badness-formatter = { path = "crates/badness-formatter", version = "0.8.2" }
-badness-parser = { path = "crates/badness-parser", version = "0.8.1", features = [
+badness-formatter = { path = "crates/badness-formatter", version = "0.8.3" }
+badness-parser = { path = "crates/badness-parser", version = "0.9.0", features = [
     "schema",
 ] }
 clap = { version = "4.5.51", features = ["derive"] }

--- a/crates/badness-formatter/CHANGELOG.md
+++ b/crates/badness-formatter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.8.3](https://github.com/jolars/badness/compare/badness-formatter-v0.8.2...badness-formatter-v0.8.3) (2026-09-03)
+
+### Bug Fixes
+- **formatter:** stabilize long optionals ([`04d8ecf`](https://github.com/jolars/badness/commit/04d8ecfc280b9071b759724dcfa7347b75b20219))
+- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)
+- **formatter:** explode column specs ([`583a98d`](https://github.com/jolars/badness/commit/583a98dd6ac96b6b1159132580c4eb33da80c345))
+
+### Dependencies
+- updated crates/badness-parser to v0.9.0
+
 ## [0.8.2](https://github.com/jolars/badness/compare/badness-formatter-v0.8.1...badness-formatter-v0.8.2) (2026-08-31)
 
 ### Bug Fixes

--- a/crates/badness-formatter/Cargo.toml
+++ b/crates/badness-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-formatter"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["latex", "bibtex", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-badness-parser = { path = "../badness-parser", version = "0.8.1" }
+badness-parser = { path = "../badness-parser", version = "0.9.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/badness-parser/CHANGELOG.md
+++ b/crates/badness-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/badness/compare/badness-parser-v0.8.1...badness-parser-v0.9.0) (2026-09-03)
+
+### Features
+- **config:** publish JSON schema ([`f83cacd`](https://github.com/jolars/badness/commit/f83cacd8c526d31c4f321e818e18fbd838e4a02d))
+
+### Bug Fixes
+- **parser:** parse long mixed optionals ([`38adc16`](https://github.com/jolars/badness/commit/38adc16dd07b4b6d85820f31dd63dd86eed6a567))
+- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)
+
 ## [0.8.1](https://github.com/jolars/badness/compare/badness-parser-v0.8.0...badness-parser-v0.8.1) (2026-08-31)
 
 ### Bug Fixes

--- a/crates/badness-parser/Cargo.toml
+++ b/crates/badness-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badness-parser"
-version = "0.8.1"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/badness/compare/badness-code-v0.22.1...badness-code-v0.23.0) (2026-09-03)
+
+### Dependencies
+- updated badness to v0.23.0
+
 ## [0.22.1](https://github.com/jolars/badness/compare/badness-code-v0.22.0...badness-code-v0.22.1) (2026-08-31)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "badness",
   "displayName": "Badness",
   "description": "Language server, formatter, and linter for LaTeX",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -483,9 +483,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "spdx"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         badness = pkgs.rustPlatform.buildRustPackage {
           pname = "badness";
-          version = "0.22.1";
+          version = "0.23.0";
 
           src = ./.;
 

--- a/npm/badness/package.json
+++ b/npm/badness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badness",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "A language, formatter, and linter for LaTeX",
   "keywords": [
     "latex",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@badness/linux-x64-gnu": "0.22.1",
-    "@badness/linux-arm64-gnu": "0.22.1",
-    "@badness/linux-x64-musl": "0.22.1",
-    "@badness/linux-arm64-musl": "0.22.1",
-    "@badness/darwin-x64": "0.22.1",
-    "@badness/darwin-arm64": "0.22.1",
-    "@badness/win32-x64": "0.22.1",
-    "@badness/win32-arm64": "0.22.1"
+    "@badness/linux-x64-gnu": "0.23.0",
+    "@badness/linux-arm64-gnu": "0.23.0",
+    "@badness/linux-x64-musl": "0.23.0",
+    "@badness/linux-arm64-musl": "0.23.0",
+    "@badness/darwin-x64": "0.23.0",
+    "@badness/darwin-arm64": "0.23.0",
+    "@badness/win32-x64": "0.23.0",
+    "@badness/win32-arm64": "0.23.0"
   }
 }


### PR DESCRIPTION
## [badness: 0.23.0](https://github.com/jolars/badness/compare/v0.22.1...v0.23.0) (2026-09-03)

### Features
- **config:** publish JSON schema ([`f83cacd`](https://github.com/jolars/badness/commit/f83cacd8c526d31c4f321e818e18fbd838e4a02d))
- **lint:** support opt-in rules ([`8cc742a`](https://github.com/jolars/badness/commit/8cc742ac68a9cda8d520ced7e5f395b1700a2978))

### Bug Fixes
- **linter:** skip positional verbatim arguments ([`08b5243`](https://github.com/jolars/badness/commit/08b52434f0d163ffbf04f6a80bc235fde17f6ec6)), fixes [#175](https://github.com/jolars/badness/issues/175)
- **linter:** ignore Beamer overlay ranges ([`d57390f`](https://github.com/jolars/badness/commit/d57390f2990f14f0859cf59431c82dd32aa872de)), fixes [#174](https://github.com/jolars/badness/issues/174)
- **formatter:** stabilize long optionals ([`04d8ecf`](https://github.com/jolars/badness/commit/04d8ecfc280b9071b759724dcfa7347b75b20219))
- **parser:** parse long mixed optionals ([`38adc16`](https://github.com/jolars/badness/commit/38adc16dd07b4b6d85820f31dd63dd86eed6a567))
- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)
- **linter:** retain braces around math operators ([`946bf2b`](https://github.com/jolars/badness/commit/946bf2bad4f091477e14d1f321c0e2cdd2781276))

### Dependencies
- updated crates/badness-formatter to v0.8.3
- updated crates/badness-parser to v0.9.0

## [crates/badness-formatter: 0.8.3](https://github.com/jolars/badness/compare/badness-formatter-v0.8.2...badness-formatter-v0.8.3) (2026-09-03)

### Bug Fixes
- **formatter:** stabilize long optionals ([`04d8ecf`](https://github.com/jolars/badness/commit/04d8ecfc280b9071b759724dcfa7347b75b20219))
- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)
- **formatter:** explode column specs ([`583a98d`](https://github.com/jolars/badness/commit/583a98dd6ac96b6b1159132580c4eb33da80c345))

### Dependencies
- updated crates/badness-parser to v0.9.0

## [crates/badness-parser: 0.9.0](https://github.com/jolars/badness/compare/badness-parser-v0.8.1...badness-parser-v0.9.0) (2026-09-03)

### Features
- **config:** publish JSON schema ([`f83cacd`](https://github.com/jolars/badness/commit/f83cacd8c526d31c4f321e818e18fbd838e4a02d))

### Bug Fixes
- **parser:** parse long mixed optionals ([`38adc16`](https://github.com/jolars/badness/commit/38adc16dd07b4b6d85820f31dd63dd86eed6a567))
- **formatter:** format empheq as math ([`e7a2140`](https://github.com/jolars/badness/commit/e7a21409a0164e27003b95521fcf19add3d719ee)), fixes [#172](https://github.com/jolars/badness/issues/172)

## [editors/code: 0.23.0](https://github.com/jolars/badness/compare/badness-code-v0.22.1...badness-code-v0.23.0) (2026-09-03)

### Dependencies
- updated badness to v0.23.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).